### PR TITLE
Re-implement treasury metrics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "eslint.alwaysShowStatus": true,
+    "eslint.packageManager": "yarn",
+    "eslint.format.enable": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },  
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Subgraph Changelog
 
+## 3.1.7 (2022-11-29)
+
+- Added market value, liquid backing and other related metrics to the daily summary record (`ProtocolMetric`) in a way that does not slow down indexing.
+
 ## 3.1.5 (2022-11-28)
 
 - Added OHM-FraxBP liquidity pool in the DAO wallet to the whitelist

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The current schema (as of 3.0.0) has three main entities:
 - `TokenRecord`: token-wallet permutations held by the treasury. These records can be aggregated to determine the treasury market value, liquid backing, etc.
 - `TokenSupply`: OHM-wallet permutations held by the treasury. These records can be aggregated to determine the OHM circulating and floating supply.
 - `ProtocolMetric`: calculated metrics for the protocol, such as the next rebase time, current APY.
+  - NOTE: some of the later-added properties (e.g. `treasuryMarketValue` are marked as optional, to work around a `504` error that is encountered while grafting)
 
 As defined in the `subgraph.yaml` file within the `ProtocolMetrics` data source (around line 417), when the `stake` function on the `OlympusStakingV3` contract is called (every rebase or ~8 hours), the indexing of the entities will commence.
 
@@ -307,6 +308,8 @@ A future improvement to this subgraph might modify the behaviour to _not_ overwr
 ### Previous Structure
 
 The previous indexing structure (before 3.0.0) aggregated the equivalents of `TokenRecord` and `TokenSupply` underneath `ProtocolMetric` entities. For each `ProtocolMetric` entitiy, there were some 10-15 properties (e.g. `treasuryMarketValue`), which resulted in blockchain data being indexed multiple times for each block. The current structure indexes only once per block, shifting the aggregation and calculation to the client-side, and results in a 15x improvement in indexing speed.
+
+NOTE: these fields have been re-added and are now calculated without requiring redundant calculations.
 
 ### Example Queries
 

--- a/networks/ethereum/config.json
+++ b/networks/ethereum/config.json
@@ -2,5 +2,5 @@
   "id": "QmYbSKNJ8g1kWnGozrJpbot8WUKVd2Sdr9r968E1MNbGY9",
   "org": "olympusdao",
   "name": "olympus-protocol-metrics",
-  "version": "3.1.5"
+  "version": "3.1.6"
 }

--- a/networks/ethereum/config.json
+++ b/networks/ethereum/config.json
@@ -2,5 +2,5 @@
   "id": "QmYbSKNJ8g1kWnGozrJpbot8WUKVd2Sdr9r968E1MNbGY9",
   "org": "olympusdao",
   "name": "olympus-protocol-metrics",
-  "version": "3.1.6"
+  "version": "3.1.7"
 }

--- a/networks/ethereum/config.json
+++ b/networks/ethereum/config.json
@@ -1,5 +1,5 @@
 {
-  "id": "QmYbSKNJ8g1kWnGozrJpbot8WUKVd2Sdr9r968E1MNbGY9",
+  "id": "QmSviE7tGZ3AaQKSFRuxVLgo1V3VwufDzb7FQGy68CbHRd",
   "org": "olympusdao",
   "name": "olympus-protocol-metrics",
   "version": "3.1.7"

--- a/networks/ethereum/config.json
+++ b/networks/ethereum/config.json
@@ -1,6 +1,6 @@
 {
-  "id": "QmSviE7tGZ3AaQKSFRuxVLgo1V3VwufDzb7FQGy68CbHRd",
+  "id": "QmQwVqCC3E5tWDivxMe2Hqo2isAkL7fJf3VTmvStssW4yo",
   "org": "olympusdao",
   "name": "olympus-protocol-metrics",
-  "version": "3.1.7"
+  "version": "3.1.8"
 }

--- a/networks/ethereum/generated/schema.ts
+++ b/networks/ethereum/generated/schema.ts
@@ -333,13 +333,21 @@ export class ProtocolMetric extends Entity {
     this.set("gOhmPrice", Value.fromBigDecimal(value));
   }
 
-  get gOhmSyntheticSupply(): BigDecimal {
+  get gOhmSyntheticSupply(): BigDecimal | null {
     const value = this.get("gOhmSyntheticSupply");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set gOhmSyntheticSupply(value: BigDecimal) {
-    this.set("gOhmSyntheticSupply", Value.fromBigDecimal(value));
+  set gOhmSyntheticSupply(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("gOhmSyntheticSupply");
+    } else {
+      this.set("gOhmSyntheticSupply", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 
   get gOhmTotalSupply(): BigDecimal {
@@ -351,13 +359,21 @@ export class ProtocolMetric extends Entity {
     this.set("gOhmTotalSupply", Value.fromBigDecimal(value));
   }
 
-  get marketCap(): BigDecimal {
+  get marketCap(): BigDecimal | null {
     const value = this.get("marketCap");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set marketCap(value: BigDecimal) {
-    this.set("marketCap", Value.fromBigDecimal(value));
+  set marketCap(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("marketCap");
+    } else {
+      this.set("marketCap", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 
   get nextDistributedOhm(): BigDecimal {
@@ -378,22 +394,38 @@ export class ProtocolMetric extends Entity {
     this.set("nextEpochRebase", Value.fromBigDecimal(value));
   }
 
-  get ohmCirculatingSupply(): BigDecimal {
+  get ohmCirculatingSupply(): BigDecimal | null {
     const value = this.get("ohmCirculatingSupply");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set ohmCirculatingSupply(value: BigDecimal) {
-    this.set("ohmCirculatingSupply", Value.fromBigDecimal(value));
+  set ohmCirculatingSupply(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("ohmCirculatingSupply");
+    } else {
+      this.set("ohmCirculatingSupply", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 
-  get ohmFloatingSupply(): BigDecimal {
+  get ohmFloatingSupply(): BigDecimal | null {
     const value = this.get("ohmFloatingSupply");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set ohmFloatingSupply(value: BigDecimal) {
-    this.set("ohmFloatingSupply", Value.fromBigDecimal(value));
+  set ohmFloatingSupply(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("ohmFloatingSupply");
+    } else {
+      this.set("ohmFloatingSupply", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 
   get ohmPrice(): BigDecimal {
@@ -441,46 +473,81 @@ export class ProtocolMetric extends Entity {
     this.set("totalValueLocked", Value.fromBigDecimal(value));
   }
 
-  get treasuryLiquidBacking(): BigDecimal {
+  get treasuryLiquidBacking(): BigDecimal | null {
     const value = this.get("treasuryLiquidBacking");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set treasuryLiquidBacking(value: BigDecimal) {
-    this.set("treasuryLiquidBacking", Value.fromBigDecimal(value));
+  set treasuryLiquidBacking(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryLiquidBacking");
+    } else {
+      this.set(
+        "treasuryLiquidBacking",
+        Value.fromBigDecimal(<BigDecimal>value)
+      );
+    }
   }
 
-  get treasuryLiquidBackingPerGOhmSynthetic(): BigDecimal {
+  get treasuryLiquidBackingPerGOhmSynthetic(): BigDecimal | null {
     const value = this.get("treasuryLiquidBackingPerGOhmSynthetic");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set treasuryLiquidBackingPerGOhmSynthetic(value: BigDecimal) {
-    this.set(
-      "treasuryLiquidBackingPerGOhmSynthetic",
-      Value.fromBigDecimal(value)
-    );
+  set treasuryLiquidBackingPerGOhmSynthetic(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryLiquidBackingPerGOhmSynthetic");
+    } else {
+      this.set(
+        "treasuryLiquidBackingPerGOhmSynthetic",
+        Value.fromBigDecimal(<BigDecimal>value)
+      );
+    }
   }
 
-  get treasuryLiquidBackingPerOhmFloating(): BigDecimal {
+  get treasuryLiquidBackingPerOhmFloating(): BigDecimal | null {
     const value = this.get("treasuryLiquidBackingPerOhmFloating");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set treasuryLiquidBackingPerOhmFloating(value: BigDecimal) {
-    this.set(
-      "treasuryLiquidBackingPerOhmFloating",
-      Value.fromBigDecimal(value)
-    );
+  set treasuryLiquidBackingPerOhmFloating(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryLiquidBackingPerOhmFloating");
+    } else {
+      this.set(
+        "treasuryLiquidBackingPerOhmFloating",
+        Value.fromBigDecimal(<BigDecimal>value)
+      );
+    }
   }
 
-  get treasuryMarketValue(): BigDecimal {
+  get treasuryMarketValue(): BigDecimal | null {
     const value = this.get("treasuryMarketValue");
-    return value!.toBigDecimal();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBigDecimal();
+    }
   }
 
-  set treasuryMarketValue(value: BigDecimal) {
-    this.set("treasuryMarketValue", Value.fromBigDecimal(value));
+  set treasuryMarketValue(value: BigDecimal | null) {
+    if (!value) {
+      this.unset("treasuryMarketValue");
+    } else {
+      this.set("treasuryMarketValue", Value.fromBigDecimal(<BigDecimal>value));
+    }
   }
 }
 

--- a/networks/ethereum/generated/schema.ts
+++ b/networks/ethereum/generated/schema.ts
@@ -333,6 +333,15 @@ export class ProtocolMetric extends Entity {
     this.set("gOhmPrice", Value.fromBigDecimal(value));
   }
 
+  get gOhmSyntheticSupply(): BigDecimal {
+    const value = this.get("gOhmSyntheticSupply");
+    return value!.toBigDecimal();
+  }
+
+  set gOhmSyntheticSupply(value: BigDecimal) {
+    this.set("gOhmSyntheticSupply", Value.fromBigDecimal(value));
+  }
+
   get gOhmTotalSupply(): BigDecimal {
     const value = this.get("gOhmTotalSupply");
     return value!.toBigDecimal();
@@ -340,6 +349,15 @@ export class ProtocolMetric extends Entity {
 
   set gOhmTotalSupply(value: BigDecimal) {
     this.set("gOhmTotalSupply", Value.fromBigDecimal(value));
+  }
+
+  get marketCap(): BigDecimal {
+    const value = this.get("marketCap");
+    return value!.toBigDecimal();
+  }
+
+  set marketCap(value: BigDecimal) {
+    this.set("marketCap", Value.fromBigDecimal(value));
   }
 
   get nextDistributedOhm(): BigDecimal {
@@ -358,6 +376,24 @@ export class ProtocolMetric extends Entity {
 
   set nextEpochRebase(value: BigDecimal) {
     this.set("nextEpochRebase", Value.fromBigDecimal(value));
+  }
+
+  get ohmCirculatingSupply(): BigDecimal {
+    const value = this.get("ohmCirculatingSupply");
+    return value!.toBigDecimal();
+  }
+
+  set ohmCirculatingSupply(value: BigDecimal) {
+    this.set("ohmCirculatingSupply", Value.fromBigDecimal(value));
+  }
+
+  get ohmFloatingSupply(): BigDecimal {
+    const value = this.get("ohmFloatingSupply");
+    return value!.toBigDecimal();
+  }
+
+  set ohmFloatingSupply(value: BigDecimal) {
+    this.set("ohmFloatingSupply", Value.fromBigDecimal(value));
   }
 
   get ohmPrice(): BigDecimal {
@@ -403,6 +439,48 @@ export class ProtocolMetric extends Entity {
 
   set totalValueLocked(value: BigDecimal) {
     this.set("totalValueLocked", Value.fromBigDecimal(value));
+  }
+
+  get treasuryLiquidBacking(): BigDecimal {
+    const value = this.get("treasuryLiquidBacking");
+    return value!.toBigDecimal();
+  }
+
+  set treasuryLiquidBacking(value: BigDecimal) {
+    this.set("treasuryLiquidBacking", Value.fromBigDecimal(value));
+  }
+
+  get treasuryLiquidBackingPerGOhmSynthetic(): BigDecimal {
+    const value = this.get("treasuryLiquidBackingPerGOhmSynthetic");
+    return value!.toBigDecimal();
+  }
+
+  set treasuryLiquidBackingPerGOhmSynthetic(value: BigDecimal) {
+    this.set(
+      "treasuryLiquidBackingPerGOhmSynthetic",
+      Value.fromBigDecimal(value)
+    );
+  }
+
+  get treasuryLiquidBackingPerOhmFloating(): BigDecimal {
+    const value = this.get("treasuryLiquidBackingPerOhmFloating");
+    return value!.toBigDecimal();
+  }
+
+  set treasuryLiquidBackingPerOhmFloating(value: BigDecimal) {
+    this.set(
+      "treasuryLiquidBackingPerOhmFloating",
+      Value.fromBigDecimal(value)
+    );
+  }
+
+  get treasuryMarketValue(): BigDecimal {
+    const value = this.get("treasuryMarketValue");
+    return value!.toBigDecimal();
+  }
+
+  set treasuryMarketValue(value: BigDecimal) {
+    this.set("treasuryMarketValue", Value.fromBigDecimal(value));
   }
 }
 

--- a/networks/ethereum/src/protocolMetrics/ProtocolMetrics.ts
+++ b/networks/ethereum/src/protocolMetrics/ProtocolMetrics.ts
@@ -62,16 +62,20 @@ export function updateProtocolMetrics(block: ethereum.Block, tokenRecords: Token
   pm.nextEpochRebase = apy_rebase[1];
 
   // Token supply
-  pm.ohmCirculatingSupply = getCirculatingSupply(tokenSupplies);
-  pm.ohmFloatingSupply = getFloatingSupply(tokenSupplies);
-  pm.gOhmSyntheticSupply = getGOhmSyntheticSupply(pm.ohmFloatingSupply, pm.currentIndex);
+  const ohmCirculatingSupply = getCirculatingSupply(tokenSupplies);
+  pm.ohmCirculatingSupply = ohmCirculatingSupply;
+  const ohmFloatingSupply = getFloatingSupply(tokenSupplies);
+  pm.ohmFloatingSupply = ohmFloatingSupply;
+  const gOhmSyntheticSupply = getGOhmSyntheticSupply(ohmFloatingSupply, pm.currentIndex);
+  pm.gOhmSyntheticSupply = gOhmSyntheticSupply;
 
   // Treasury
-  pm.marketCap = getMarketCap(pm.ohmPrice, pm.ohmCirculatingSupply);
+  pm.marketCap = getMarketCap(pm.ohmPrice, ohmCirculatingSupply);
   pm.treasuryMarketValue = getTreasuryMarketValue(tokenRecords);
-  pm.treasuryLiquidBacking = getTreasuryLiquidBacking(tokenRecords);
-  pm.treasuryLiquidBackingPerOhmFloating = getTreasuryLiquidBackingPerOhmFloating(pm.treasuryLiquidBacking, pm.ohmFloatingSupply);
-  pm.treasuryLiquidBackingPerGOhmSynthetic = getTreasuryLiquidBackingPerGOhmSynthetic(pm.treasuryLiquidBacking, pm.gOhmSyntheticSupply);
+  const liquidBacking = getTreasuryLiquidBacking(tokenRecords);
+  pm.treasuryLiquidBacking = liquidBacking;
+  pm.treasuryLiquidBackingPerOhmFloating = getTreasuryLiquidBackingPerOhmFloating(liquidBacking, ohmFloatingSupply);
+  pm.treasuryLiquidBackingPerGOhmSynthetic = getTreasuryLiquidBackingPerGOhmSynthetic(liquidBacking, gOhmSyntheticSupply);
 
   pm.save();
 }

--- a/networks/ethereum/src/protocolMetrics/ProtocolMetrics.ts
+++ b/networks/ethereum/src/protocolMetrics/ProtocolMetrics.ts
@@ -1,12 +1,15 @@
-import { BigDecimal, BigInt, log } from "@graphprotocol/graph-ts";
+import { BigInt, log } from "@graphprotocol/graph-ts";
 import { ethereum } from "@graphprotocol/graph-ts";
 
+import { TokenRecord } from "../../../shared/generated/schema";
 import { getISO8601DateStringFromTimestamp } from "../../../shared/src/utils/DateHelper";
 import { StakeCall } from "../../generated/ProtocolMetrics/OlympusStakingV3";
-import { ProtocolMetric } from "../../generated/schema";
-import { getGOhmTotalSupply } from "../utils/GOhmCalculations";
+import { ProtocolMetric, TokenSupply } from "../../generated/schema";
+import { getGOhmSyntheticSupply, getGOhmTotalSupply } from "../utils/GOhmCalculations";
 import {
+  getCirculatingSupply,
   getCurrentIndex,
+  getFloatingSupply,
   getSOhmCirculatingSupply,
   getTotalSupply,
   getTotalValueLocked,
@@ -14,6 +17,7 @@ import {
 import { getBaseOhmUsdRate } from "../utils/Price";
 import { generateTokenRecords, generateTokenSupply } from "../utils/TreasuryCalculations";
 import { getAPY_Rebase, getNextOHMRebase } from "./Rebase";
+import { getMarketCap, getTreasuryLiquidBacking, getTreasuryLiquidBackingPerGOhmSynthetic, getTreasuryLiquidBackingPerOhmFloating, getTreasuryMarketValue } from "./TreasuryMetrics";
 
 export function loadOrCreateProtocolMetric(timestamp: BigInt): ProtocolMetric {
   const dateString = getISO8601DateStringFromTimestamp(timestamp);
@@ -21,27 +25,14 @@ export function loadOrCreateProtocolMetric(timestamp: BigInt): ProtocolMetric {
   let protocolMetric = ProtocolMetric.load(dateString);
   if (protocolMetric == null) {
     protocolMetric = new ProtocolMetric(dateString);
-    protocolMetric.block = BigInt.fromString("-1");
-    protocolMetric.currentAPY = BigDecimal.fromString("0");
-    protocolMetric.currentIndex = BigDecimal.fromString("0");
     protocolMetric.date = dateString;
-    protocolMetric.gOhmPrice = BigDecimal.fromString("0");
-    protocolMetric.gOhmTotalSupply = BigDecimal.fromString("0");
-    protocolMetric.nextDistributedOhm = BigDecimal.fromString("0");
-    protocolMetric.nextEpochRebase = BigDecimal.fromString("0");
-    protocolMetric.ohmPrice = BigDecimal.fromString("0");
-    protocolMetric.ohmTotalSupply = BigDecimal.fromString("0");
-    protocolMetric.sOhmCirculatingSupply = BigDecimal.fromString("0");
     protocolMetric.timestamp = timestamp;
-    protocolMetric.totalValueLocked = BigDecimal.fromString("0");
-
-    protocolMetric.save();
   }
 
   return protocolMetric as ProtocolMetric;
 }
 
-export function updateProtocolMetrics(block: ethereum.Block): void {
+export function updateProtocolMetrics(block: ethereum.Block, tokenRecords: TokenRecord[], tokenSupplies: TokenSupply[]): void {
   const blockNumber = block.number;
   log.info("Starting protocol metrics for block {}", [blockNumber.toString()]);
 
@@ -70,16 +61,31 @@ export function updateProtocolMetrics(block: ethereum.Block): void {
   pm.currentAPY = apy_rebase[0];
   pm.nextEpochRebase = apy_rebase[1];
 
+  // Token supply
+  pm.ohmCirculatingSupply = getCirculatingSupply(tokenSupplies);
+  pm.ohmFloatingSupply = getFloatingSupply(tokenSupplies);
+  pm.gOhmSyntheticSupply = getGOhmSyntheticSupply(pm.ohmFloatingSupply, pm.currentIndex);
+
+  // Treasury
+  pm.marketCap = getMarketCap(pm.ohmPrice, pm.ohmCirculatingSupply);
+  pm.treasuryMarketValue = getTreasuryMarketValue(tokenRecords);
+  pm.treasuryLiquidBacking = getTreasuryLiquidBacking(tokenRecords);
+  pm.treasuryLiquidBackingPerOhmFloating = getTreasuryLiquidBackingPerOhmFloating(pm.treasuryLiquidBacking, pm.ohmFloatingSupply);
+  pm.treasuryLiquidBackingPerGOhmSynthetic = getTreasuryLiquidBackingPerGOhmSynthetic(pm.treasuryLiquidBacking, pm.gOhmSyntheticSupply);
+
   pm.save();
 }
 
 export function handleMetrics(call: StakeCall): void {
   log.debug("handleMetrics: *** Indexing block {}", [call.block.number.toString()]);
-  updateProtocolMetrics(call.block);
 
   // TokenRecord
-  generateTokenRecords(call.block.timestamp, call.block.number);
+  const tokenRecords = generateTokenRecords(call.block.timestamp, call.block.number);
 
   // TokenSupply
-  generateTokenSupply(call.block.timestamp, call.block.number);
+  const tokenSupplies = generateTokenSupply(call.block.timestamp, call.block.number);
+
+  // Use the generated records to calculate protocol/treasury metrics
+  // Otherwise we would be re-generating the records
+  updateProtocolMetrics(call.block, tokenRecords, tokenSupplies);
 }

--- a/networks/ethereum/src/protocolMetrics/TreasuryMetrics.ts
+++ b/networks/ethereum/src/protocolMetrics/TreasuryMetrics.ts
@@ -1,0 +1,51 @@
+import { BigDecimal } from "@graphprotocol/graph-ts";
+
+import { TokenRecord } from "../../../shared/generated/schema";
+
+/**
+ * OHM price * circulating supply
+ */
+export function getMarketCap(ohmPrice: BigDecimal, circulatingSupply: BigDecimal): BigDecimal {
+    return ohmPrice.times(circulatingSupply);
+}
+
+/**
+ * Includes all assets in the treasury
+ */
+export function getTreasuryMarketValue(tokenRecords: TokenRecord[]): BigDecimal {
+    let total = BigDecimal.zero();
+
+    for (let i = 0; i < tokenRecords.length; i++) {
+        const tokenRecord = tokenRecords[i];
+
+        total = total.plus(tokenRecord.value);
+    }
+
+    return total;
+}
+
+/**
+ * Includes all liquid assets in the treasury, excluding the value of OHM
+ */
+export function getTreasuryLiquidBacking(tokenRecords: TokenRecord[]): BigDecimal {
+    let total = BigDecimal.zero();
+
+    for (let i = 0; i < tokenRecords.length; i++) {
+        const tokenRecord = tokenRecords[i];
+        if (!tokenRecord.isLiquid) {
+            continue;
+        }
+
+        total = total.plus(tokenRecord.valueExcludingOhm);
+    }
+
+    return total;
+}
+
+export function getTreasuryLiquidBackingPerOhmFloating(liquidBacking: BigDecimal, ohmFloatingSupply: BigDecimal): BigDecimal {
+    return liquidBacking.div(ohmFloatingSupply);
+}
+
+export function getTreasuryLiquidBackingPerGOhmSynthetic(liquidBacking: BigDecimal, gOhmSupply: BigDecimal): BigDecimal {
+    return liquidBacking.div(gOhmSupply);
+}

--- a/networks/ethereum/src/utils/GOhmCalculations.ts
+++ b/networks/ethereum/src/utils/GOhmCalculations.ts
@@ -25,3 +25,12 @@ export function getGOhmTotalSupply(blockNumber: BigInt): BigDecimal {
 
   return toDecimal(contract.totalSupply(), contract.decimals());
 }
+
+/**
+ * gOHM circulating supply is synthetically calculated as:
+ *
+ * OHM floating supply / current index
+ */
+export function getGOhmSyntheticSupply(ohmFloatingSupply: BigDecimal, currentIndex: BigDecimal): BigDecimal {
+  return ohmFloatingSupply.div(currentIndex);
+}

--- a/networks/ethereum/src/utils/TreasuryCalculations.ts
+++ b/networks/ethereum/src/utils/TreasuryCalculations.ts
@@ -1,6 +1,10 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 
+import { TokenRecord } from "../../../shared/generated/schema";
+import { pushArray } from "../../../shared/src/utils/ArrayHelper";
+import { TokenSupply } from "../../generated/schema";
 import { getOwnedLiquidityPoolValue } from "../liquidity/LiquidityCalculations";
+import { pushTokenSupplyArray } from "./ArrayHelper";
 import {
   getProtocolOwnedLiquiditySupplyRecords,
   getTotalSupplyRecord,
@@ -20,25 +24,51 @@ import { getVolatileTokenBalances } from "./TokenVolatile";
  * @param blockNumber
  * @returns
  */
-export function generateTokenRecords(timestamp: BigInt, blockNumber: BigInt): void {
+export function generateTokenRecords(timestamp: BigInt, blockNumber: BigInt): TokenRecord[] {
+  const records: TokenRecord[] = [];
+
   // Stable without protocol-owned liquidity
-  getStablecoinBalances(timestamp, false, blockNumber);
+  pushArray(
+    records,
+    getStablecoinBalances(timestamp, false, blockNumber),
+  );
 
   // Volatile without protocol-owned liquidity, but blue-cip assets
-  getVolatileTokenBalances(timestamp, false, false, true, blockNumber);
+  pushArray(
+    records,
+    getVolatileTokenBalances(timestamp, false, false, true, blockNumber),
+  );
 
   // Protocol-owned liquidity
-  getOwnedLiquidityPoolValue(timestamp, blockNumber);
+  pushArray(
+    records,
+    getOwnedLiquidityPoolValue(timestamp, blockNumber),
+  );
+
+  return records;
 }
 
-export function generateTokenSupply(timestamp: BigInt, blockNumber: BigInt): void {
+export function generateTokenSupply(timestamp: BigInt, blockNumber: BigInt): TokenSupply[] {
+  const records: TokenSupply[] = [];
+
   // OHM
   // Total supply
-  getTotalSupplyRecord(timestamp, blockNumber);
+  pushTokenSupplyArray(
+    records,
+    [getTotalSupplyRecord(timestamp, blockNumber)],
+  );
 
   // Treasury OHM
-  getTreasuryOHMRecords(timestamp, blockNumber);
+  pushTokenSupplyArray(
+    records,
+    getTreasuryOHMRecords(timestamp, blockNumber),
+  );
 
   // Floating supply
-  getProtocolOwnedLiquiditySupplyRecords(timestamp, blockNumber);
+  pushTokenSupplyArray(
+    records,
+    getProtocolOwnedLiquiditySupplyRecords(timestamp, blockNumber),
+  );
+
+  return records;
 }

--- a/networks/ethereum/subgraph.yaml
+++ b/networks/ethereum/subgraph.yaml
@@ -3,7 +3,7 @@ description: Olympus Protocol Metrics Subgraph
 features:
   - grafting
 graft:
-  base: QmeDGGjQknnyTKULkog8pcgsyqan2XwZNgBo8ZcyHSE43C # 3.0.39 price-snapshot branch
+  base: QmYbSKNJ8g1kWnGozrJpbot8WUKVd2Sdr9r968E1MNbGY9 # https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph/pull/117
   block: 15998131 # TRSRY deployment
 repository: https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph
 schema:

--- a/schema.graphql
+++ b/schema.graphql
@@ -35,14 +35,22 @@ type ProtocolMetric @entity {
   currentIndex: BigDecimal!
   date: String! # YYYY-MM-DD
   gOhmPrice: BigDecimal!
+  gOhmSyntheticSupply: BigDecimal!
   gOhmTotalSupply: BigDecimal!
+  marketCap: BigDecimal!
   nextDistributedOhm: BigDecimal!
   nextEpochRebase: BigDecimal!
+  ohmCirculatingSupply: BigDecimal!
+  ohmFloatingSupply: BigDecimal!
   ohmPrice: BigDecimal!
   ohmTotalSupply: BigDecimal!
   sOhmCirculatingSupply: BigDecimal! # Returned by the sOHM contract, so can be included here
   timestamp: BigInt! # Unix timestamp in UTC
   totalValueLocked: BigDecimal!
+  treasuryLiquidBacking: BigDecimal!
+  treasuryLiquidBackingPerGOhmSynthetic: BigDecimal!
+  treasuryLiquidBackingPerOhmFloating: BigDecimal!
+  treasuryMarketValue: BigDecimal!
 }
 
 type BondDiscount @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -35,22 +35,22 @@ type ProtocolMetric @entity {
   currentIndex: BigDecimal!
   date: String! # YYYY-MM-DD
   gOhmPrice: BigDecimal!
-  gOhmSyntheticSupply: BigDecimal!
+  gOhmSyntheticSupply: BigDecimal
   gOhmTotalSupply: BigDecimal!
-  marketCap: BigDecimal!
+  marketCap: BigDecimal
   nextDistributedOhm: BigDecimal!
   nextEpochRebase: BigDecimal!
-  ohmCirculatingSupply: BigDecimal!
-  ohmFloatingSupply: BigDecimal!
+  ohmCirculatingSupply: BigDecimal
+  ohmFloatingSupply: BigDecimal
   ohmPrice: BigDecimal!
   ohmTotalSupply: BigDecimal!
   sOhmCirculatingSupply: BigDecimal! # Returned by the sOHM contract, so can be included here
   timestamp: BigInt! # Unix timestamp in UTC
   totalValueLocked: BigDecimal!
-  treasuryLiquidBacking: BigDecimal!
-  treasuryLiquidBackingPerGOhmSynthetic: BigDecimal!
-  treasuryLiquidBackingPerOhmFloating: BigDecimal!
-  treasuryMarketValue: BigDecimal!
+  treasuryLiquidBacking: BigDecimal
+  treasuryLiquidBackingPerGOhmSynthetic: BigDecimal
+  treasuryLiquidBackingPerOhmFloating: BigDecimal
+  treasuryMarketValue: BigDecimal
 }
 
 type BondDiscount @entity {


### PR DESCRIPTION
This PR reinstates the treasury metrics (Ethereum only) that were removed due to slow indexing.

Confirmed against:
- Manual addition of Ethereum assets against market value (minus non-Ethereum assets)
- OHM floating/circulating supply

To obtain the latest values:
```
query MyQuery {
  protocolMetrics(orderBy: block, orderDirection: desc, first: 1) {
    block
    date
    treasuryLiquidBacking
    treasuryLiquidBackingPerOhmFloating
    treasuryMarketValue
  }
}
```