### PR TITLE
Disable Arbitrum grafting

### DIFF
--- a/subgraphs/arbitrum/config.json
+++ b/subgraphs/arbitrum/config.json
@@ -2,5 +2,5 @@
   "id": "QmU4Rcn5oZB9dPrXvfe5L3PfgqEFAxC8MP4YsR7b45UWTL",
   "org": "olympusdao",
   "name": "protocol-metrics-arbitrum",
-  "version": "1.1.4"
+  "version": "1.1.6"
 }

--- a/subgraphs/arbitrum/config.json
+++ b/subgraphs/arbitrum/config.json
@@ -1,5 +1,5 @@
 {
-  "id": "QmU4Rcn5oZB9dPrXvfe5L3PfgqEFAxC8MP4YsR7b45UWTL",
+  "id": "QmcZ5q9dX6ziwz5rv1rksgt8qFd6E1UEndy12kkGFqeiJz",
   "org": "olympusdao",
   "name": "protocol-metrics-arbitrum",
   "version": "1.1.6"

--- a/subgraphs/arbitrum/subgraph.yaml
+++ b/subgraphs/arbitrum/subgraph.yaml
@@ -1,11 +1,11 @@
 specVersion: 0.0.4
 description: Olympus Protocol Metrics Subgraph - Arbitrum
 repository: https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph
-features:
-  - grafting
-graft:
-  base: QmUWRimfjsqDP4CKwZ2zQ8dJxyY3yee3U5hSPQmZ6D83g5
-  block: 83000000 # 2023-04-22
+# features:
+#   - grafting
+# graft:
+#   base: QmUWRimfjsqDP4CKwZ2zQ8dJxyY3yee3U5hSPQmZ6D83g5
+#   block: 83000000 # 2023-04-22
 schema:
   file: ../../schema.graphql
 dataSources:


### PR DESCRIPTION
The existing deployment returns the following error:
```json
{
  "errors": [
    {
      "message": "Failed to get entities from store: relation \"sgd549336.token_record\" does not exist, query = /* controller='filter',application='sgd549336',route='be685180e8149446-3048f0159a84281c',action='85161760' */\nselect 'TokenRecord' as entity, to_jsonb(c.*) as data from (select  c.*\n  from \"sgd549336\".\"token_record\" c\n where c.block_range @> $1\n\n order by \"block\" desc, \"id\" desc\n limit 100) c -- binds: [85161760]"
    }
  ]
}
```

Removed grafting and deployed a new version, to try and work around this.