### PR TITLE
Add client release dry-run workflow

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -1,0 +1,140 @@
+name: Release treasury-subgraph-client
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: Version to release. Must match apps/client/package.json.
+        required: true
+        type: string
+      mode:
+        description: Run a safe package rehearsal or stage the package on npm.
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - stage
+
+permissions:
+  contents: read
+
+concurrency:
+  group: treasury-subgraph-client-release
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: apps/client
+  PACKAGE_NAME: "@olympusdao/treasury-subgraph-client"
+
+jobs:
+  validate-pack:
+    name: Validate and pack package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    outputs:
+      filename: ${{ steps.pack.outputs.filename }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+
+      - name: Install npm with staged publishing support
+        run: npm install -g npm@11.15.0
+
+      - name: Release preflight
+        id: release
+        run: pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts validate
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+
+      - name: Run client release checks
+        run: pnpm --dir "$PACKAGE_DIR" run release:check
+
+      - name: Pack release artifact for review
+        id: pack
+        run: pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts pack
+        env:
+          PACK_DESTINATION: ${{ runner.temp }}
+          NPM_CACHE_DIR: ${{ runner.temp }}/npm-cache
+
+      - name: Write GitHub release notes
+        run: pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts notes
+        env:
+          RELEASE_NOTES_PATH: ${{ runner.temp }}/client-release-notes.md
+
+      - name: Upload packed package artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: treasury-subgraph-client-${{ steps.release.outputs.version }}
+          path: |
+            ${{ steps.pack.outputs.tarball }}
+            ${{ steps.pack.outputs.pack_json }}
+            ${{ runner.temp }}/client-release-notes.md
+          if-no-files-found: error
+
+      - name: Write dry-run summary
+        if: ${{ inputs.mode == 'dry-run' }}
+        run: |
+          {
+            echo "## Client package release dry-run"
+            echo ""
+            echo "- Package: \`$PACKAGE_NAME@${{ steps.release.outputs.version }}\`"
+            echo "- Tag that would be created in stage mode: \`${{ steps.release.outputs.tag }}\`"
+            echo "- Packed artifact: \`${{ steps.pack.outputs.filename }}\`"
+            echo ""
+            echo "No npm staging, git tag, or GitHub Release was created."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  stage-npm:
+    name: Stage package on npm
+    if: ${{ inputs.mode == 'stage' }}
+    needs: validate-pack
+    runs-on: ubuntu-latest
+    environment: npm-stage
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download packed package artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: treasury-subgraph-client-${{ needs.validate-pack.outputs.version }}
+          path: ${{ runner.temp }}/client-package
+
+      - name: Install npm with staged publishing support
+        run: npm install -g npm@11.15.0
+
+      - name: Stage package on npm
+        run: npm stage publish "$RUNNER_TEMP/client-package/${{ needs.validate-pack.outputs.filename }}" --access public --cache "$RUNNER_TEMP/npm-cache"
+
+  github-release:
+    name: Create GitHub release
+    if: ${{ inputs.mode == 'stage' }}
+    needs:
+      - validate-pack
+      - stage-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download packed package artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: treasury-subgraph-client-${{ needs.validate-pack.outputs.version }}
+          path: ${{ runner.temp }}/client-package
+
+      - name: Create GitHub release
+        run: gh release create "${{ needs.validate-pack.outputs.tag }}" "$RUNNER_TEMP/client-package/${{ needs.validate-pack.outputs.filename }}" "$RUNNER_TEMP/client-package/client-pack.json" --title "$PACKAGE_NAME@${{ needs.validate-pack.outputs.version }}" --notes-file "$RUNNER_TEMP/client-package/client-release-notes.md" --target "${{ github.sha }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/client-release.md
+++ b/docs/client-release.md
@@ -1,0 +1,56 @@
+# Client Package Release
+
+The `@olympusdao/treasury-subgraph-client` package is released with the manual
+GitHub Actions workflow **Release treasury-subgraph-client**.
+
+## Why this workflow lives on master
+
+GitHub only shows a `workflow_dispatch` workflow in the Actions UI after the
+workflow file exists on the repository default branch. Keep this workflow on
+`master` even when the package version being tested or released lives on a
+feature branch.
+
+When running the workflow from the Actions UI, use the branch selector to choose
+the branch or tag that contains the package source, `apps/client/package.json`,
+`apps/client/scripts/ci-release.ts`, and the matching changelog entry.
+
+## Modes
+
+Use `mode=dry-run` first. This is the default.
+
+Dry-run mode:
+
+- validates `expected_version` against `apps/client/package.json`
+- runs the client release checks
+- packs the package
+- uploads the tarball, npm pack metadata, and release notes as workflow
+  artifacts
+- does not stage anything on npm
+- does not create a git tag
+- does not create a GitHub Release
+
+Use `mode=stage` only after the dry-run artifact has been reviewed.
+
+Stage mode:
+
+- performs the same validation and package packing
+- stages the tarball on npm through trusted publishing
+- creates the `treasury-subgraph-client-v<version>` GitHub tag and Release only
+  after npm staging succeeds
+
+The staged npm package still needs manual approval in npm's web UI before it is
+published to the live registry.
+
+## Running A Release
+
+1. Open **Actions**.
+2. Select **Release treasury-subgraph-client**.
+3. Click **Run workflow**.
+4. Select the branch containing the intended package release.
+5. Enter `expected_version`, for example `3.0.0`.
+6. Leave `mode` as `dry-run`.
+7. Review the uploaded workflow artifacts.
+8. Rerun the workflow with the same branch and `mode=stage`.
+9. Review and approve the staged package on npmjs.com.
+
+Do not use local npm tokens or local `npm stage publish` for this package.


### PR DESCRIPTION
## Summary
- add a manual treasury-subgraph-client release workflow on the default-branch line
- add a required release mode with dry-run as the default and stage as the write path
- document using the Actions branch selector to dry-run or stage a package branch

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/client-release.yml"); puts "workflow yaml ok"'
- git diff --check

This PR is intentionally based on master so the workflow can be merged without pulling in the Envio branch changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated release workflow supporting manual triggering with configurable options for `expected_version` and release mode.
  * Supports `dry-run` mode for validation without creating releases.
  * Supports `stage` mode for publishing to npm staging environment.

* **Documentation**
  * Added release process documentation detailing workflow usage, required inputs, and operational differences between modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->