### PR TITLE
Fix metrics publisher month shard regeneration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
-      - name: Lint
-        run: pnpm lint:check
+      - name: Check
+        run: pnpm run check
 
   tests:
     runs-on: ubuntu-latest

--- a/apps/client/scripts/ci-release.ts
+++ b/apps/client/scripts/ci-release.ts
@@ -45,7 +45,10 @@ function run(command: string, args: string[], cwd = repoRoot): void {
 }
 
 function getExitStatus(error: unknown): number | undefined {
-  return typeof error === "object" && error !== null && "status" in error && typeof error.status === "number"
+  return typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number"
     ? error.status
     : undefined;
 }
@@ -70,8 +73,11 @@ function errorText(value: unknown): string {
 function isNpmRegistryNotFoundError(error: unknown): boolean {
   const code = errorText(getErrorProperty(error, "code"));
   const stderr = errorText(getErrorProperty(error, "stderr"));
-  const message = error instanceof Error ? error.message : errorText(getErrorProperty(error, "message"));
-  return code === "E404" || stderr.includes("E404") || stderr.includes("404") || message.includes("E404");
+  const message =
+    error instanceof Error ? error.message : errorText(getErrorProperty(error, "message"));
+  return (
+    code === "E404" || stderr.includes("E404") || stderr.includes("404") || message.includes("E404")
+  );
 }
 
 function readPackage(): Required<PackageJson> {
@@ -106,11 +112,16 @@ function readChangelogSection(version: string): string {
   const releaseHeading = new RegExp(`^## \\[v?${escapeRegExp(version)}\\](?:\\s+-\\s+.+)?\\s*$`);
   const start = lines.findIndex((line) => releaseHeading.test(line));
   if (start === -1) {
-    fail(`Missing changelog section for ${packageName}@${version}. Expected heading like "## [v${version}]".`);
+    fail(
+      `Missing changelog section for ${packageName}@${version}. Expected heading like "## [v${version}]".`,
+    );
   }
 
   const end = lines.findIndex((line, index) => index > start && isChangelogReleaseHeading(line));
-  return lines.slice(start, end === -1 ? undefined : end).join("\n").trim();
+  return lines
+    .slice(start, end === -1 ? undefined : end)
+    .join("\n")
+    .trim();
 }
 
 function setGithubOutput(values: Record<string, string>): void {
@@ -164,7 +175,11 @@ function assertVersionNotPublished(): void {
 
 function valueContainsVersion(value: unknown, version: string): boolean {
   if (typeof value === "string") {
-    return value === version || value === `${packageName}@${version}` || value.includes(`${packageName}@${version}`);
+    return (
+      value === version ||
+      value === `${packageName}@${version}` ||
+      value.includes(`${packageName}@${version}`)
+    );
   }
   if (Array.isArray(value)) {
     return value.some((item) => valueContainsVersion(item, version));

--- a/apps/client/scripts/release-check.ts
+++ b/apps/client/scripts/release-check.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import process from "node:process";
-import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 type PackFile = {
@@ -49,16 +49,25 @@ function assertPackageMetadata(): void {
     fail(`Unexpected package name: ${packageJson.name ?? "(missing)"}`);
   }
 
-  if (packageJson.version === undefined || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(packageJson.version)) {
-    fail(`Package version must be a concrete semver version, got: ${packageJson.version ?? "(missing)"}`);
+  if (
+    packageJson.version === undefined ||
+    !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(packageJson.version)
+  ) {
+    fail(
+      `Package version must be a concrete semver version, got: ${packageJson.version ?? "(missing)"}`,
+    );
   }
 
   if (Object.keys(packageJson.dependencies ?? {}).length > 0) {
-    fail("Client package should not publish runtime dependencies without an explicit release-process update.");
+    fail(
+      "Client package should not publish runtime dependencies without an explicit release-process update.",
+    );
   }
 
   if (Object.keys(packageJson.peerDependencies ?? {}).length > 0) {
-    fail("Client package should not publish peer dependencies without an explicit release-process update.");
+    fail(
+      "Client package should not publish peer dependencies without an explicit release-process update.",
+    );
   }
 }
 
@@ -72,7 +81,12 @@ function assertNodeVersion(): void {
 function assertNpmSupportsStagedPublishing(): void {
   const version = capture("npm", ["--version"]).trim();
   const [major = 0, minor = 0] = version.split(".").map((part) => Number.parseInt(part, 10));
-  if (!Number.isInteger(major) || !Number.isInteger(minor) || major < 11 || (major === 11 && minor < 15)) {
+  if (
+    !Number.isInteger(major) ||
+    !Number.isInteger(minor) ||
+    major < 11 ||
+    (major === 11 && minor < 15)
+  ) {
     fail(`npm 11.15.0+ is required for staged publishing, got ${version}`);
   }
 }
@@ -95,7 +109,11 @@ function assertPackAllowlist(): void {
   const disallowed = files
     .map((file) => file.path)
     .filter(
-      (path) => path !== "package.json" && path !== "CHANGELOG.md" && path !== "openapi.json" && !path.startsWith("dist/"),
+      (path) =>
+        path !== "package.json" &&
+        path !== "CHANGELOG.md" &&
+        path !== "openapi.json" &&
+        !path.startsWith("dist/"),
     );
 
   if (files.length === 0) {

--- a/apps/client/src/client.ts
+++ b/apps/client/src/client.ts
@@ -53,7 +53,10 @@ export class TreasurySubgraphClient {
     input?: Operations[OperationName]["input"];
   }): Promise<Operations[OperationName]["response"]>;
   async query(params: { operationName: string; input?: Record<string, unknown> }): Promise<unknown>;
-  async query(params: { operationName: string; input?: Record<string, unknown> }): Promise<unknown> {
+  async query(params: {
+    operationName: string;
+    input?: Record<string, unknown>;
+  }): Promise<unknown> {
     const url = this.url(getLegacyOperationPath(params.operationName));
     if (params.input !== undefined) {
       url.searchParams.set("wg_variables", JSON.stringify(params.input));
@@ -62,27 +65,37 @@ export class TreasurySubgraphClient {
   }
 
   /** @deprecated Use `getDailyMetrics` or `query({ operationName: "latest/metrics" })` instead. */
-  async getLatestMetrics(input?: IgnoreCacheInput): Promise<Operations["latest/metrics"]["response"]> {
+  async getLatestMetrics(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["latest/metrics"]["response"]> {
     return this.query({ operationName: "latest/metrics", input });
   }
 
   /** @deprecated Use `getDailyMetrics` or `query({ operationName: "earliest/metrics" })` instead. */
-  async getEarliestMetrics(input?: IgnoreCacheInput): Promise<Operations["earliest/metrics"]["response"]> {
+  async getEarliestMetrics(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["earliest/metrics"]["response"]> {
     return this.query({ operationName: "earliest/metrics", input });
   }
 
   /** @deprecated Use `getDailyMetrics` or `query({ operationName: "paginated/metrics" })` instead. */
-  async getPaginatedMetrics(input: PaginatedMetricsInput): Promise<Operations["paginated/metrics"]["response"]> {
+  async getPaginatedMetrics(
+    input: PaginatedMetricsInput,
+  ): Promise<Operations["paginated/metrics"]["response"]> {
     return this.query({ operationName: "paginated/metrics", input });
   }
 
   /** @deprecated Use `getDailyTreasuryAssets` or `query({ operationName: "latest/tokenRecords" })` instead. */
-  async getLatestTokenRecords(input?: IgnoreCacheInput): Promise<Operations["latest/tokenRecords"]["response"]> {
+  async getLatestTokenRecords(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["latest/tokenRecords"]["response"]> {
     return this.query({ operationName: "latest/tokenRecords", input });
   }
 
   /** @deprecated Use `getDailyTreasuryAssets` or `query({ operationName: "earliest/tokenRecords" })` instead. */
-  async getEarliestTokenRecords(input?: IgnoreCacheInput): Promise<Operations["earliest/tokenRecords"]["response"]> {
+  async getEarliestTokenRecords(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["earliest/tokenRecords"]["response"]> {
     return this.query({ operationName: "earliest/tokenRecords", input });
   }
 
@@ -94,12 +107,16 @@ export class TreasurySubgraphClient {
   }
 
   /** @deprecated Use `getDailyOhmSupply` or `query({ operationName: "latest/tokenSupplies" })` instead. */
-  async getLatestTokenSupplies(input?: IgnoreCacheInput): Promise<Operations["latest/tokenSupplies"]["response"]> {
+  async getLatestTokenSupplies(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["latest/tokenSupplies"]["response"]> {
     return this.query({ operationName: "latest/tokenSupplies", input });
   }
 
   /** @deprecated Use `getDailyOhmSupply` or `query({ operationName: "earliest/tokenSupplies" })` instead. */
-  async getEarliestTokenSupplies(input?: IgnoreCacheInput): Promise<Operations["earliest/tokenSupplies"]["response"]> {
+  async getEarliestTokenSupplies(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["earliest/tokenSupplies"]["response"]> {
     return this.query({ operationName: "earliest/tokenSupplies", input });
   }
 
@@ -111,7 +128,9 @@ export class TreasurySubgraphClient {
   }
 
   /** @deprecated Use `query({ operationName: "latest/protocolMetrics" })` only for legacy compatibility. */
-  async getLatestProtocolMetrics(input?: IgnoreCacheInput): Promise<Operations["latest/protocolMetrics"]["response"]> {
+  async getLatestProtocolMetrics(
+    input?: IgnoreCacheInput,
+  ): Promise<Operations["latest/protocolMetrics"]["response"]> {
     return this.query({ operationName: "latest/protocolMetrics", input });
   }
 
@@ -242,7 +261,11 @@ function appendRange(url: URL, input: { start: string; end?: string }): void {
   }
 }
 
-function splitRange(input: { start: string; end: string; maxDays: number }): Array<{ start: string; end: string }> {
+function splitRange(input: {
+  start: string;
+  end: string;
+  maxDays: number;
+}): Array<{ start: string; end: string }> {
   if (input.maxDays < 1) {
     throw new Error(`maxRangeDays must be greater than zero, got ${input.maxDays}`);
   }
@@ -256,7 +279,9 @@ function splitRange(input: { start: string; end: string; maxDays: number }): Arr
   const chunks: Array<{ start: string; end: string }> = [];
   let cursor = start;
   while (cursor.getTime() <= end.getTime()) {
-    const chunkEnd = new Date(Math.min(end.getTime(), cursor.getTime() + (input.maxDays - 1) * DAY_MS));
+    const chunkEnd = new Date(
+      Math.min(end.getTime(), cursor.getTime() + (input.maxDays - 1) * DAY_MS),
+    );
     chunks.push({ start: formatDate(cursor), end: formatDate(chunkEnd) });
     cursor = new Date(chunkEnd.getTime() + DAY_MS);
   }

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -1,7 +1,12 @@
-export { createClient, DEFAULT_BASE_URL, TreasurySubgraphClient, type ClientConfig } from "./client.js";
-export { getOpenApiDocument } from "../../../packages/metrics-artifacts/src/index.js";
 export * from "../../../packages/metrics-artifacts/src/date-ranges.js";
+export { getOpenApiDocument } from "../../../packages/metrics-artifacts/src/index.js";
 export * from "../../../packages/metrics-artifacts/src/legacy-shape.js";
 export * from "../../../packages/metrics-artifacts/src/openapi.js";
-export { CHAIN_NAMES } from "../../../packages/metrics-artifacts/src/types.js";
 export type * from "../../../packages/metrics-artifacts/src/types.js";
+export { CHAIN_NAMES } from "../../../packages/metrics-artifacts/src/types.js";
+export {
+  type ClientConfig,
+  createClient,
+  DEFAULT_BASE_URL,
+  TreasurySubgraphClient,
+} from "./client.js";

--- a/apps/client/tests/client.test.ts
+++ b/apps/client/tests/client.test.ts
@@ -4,22 +4,22 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, expectTypeOf, test, vi } from "vitest";
-
-import { createClient, DEFAULT_BASE_URL } from "../src";
+import { getOpenApiDocument as getCanonicalOpenApiDocument } from "../../../packages/metrics-artifacts/src";
 import {
-  getOpenApiDocument,
   type ChainTokenRecords,
   type ChainTokenSupplies,
+  createClient,
+  DEFAULT_BASE_URL,
+  getOpenApiDocument,
   type Health,
   type Metric,
-  type Operations,
   type OhmSupply,
+  type Operations,
   type TokenRecord,
   type TokenSupply,
   type TreasuryAsset,
   type WundergraphResponse,
 } from "../src";
-import { getOpenApiDocument as getCanonicalOpenApiDocument } from "../../../packages/metrics-artifacts/src";
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 const CLIENT_DIR = resolve(TEST_DIR, "..");
@@ -103,8 +103,13 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
   });
 
   test("legacy health query maps to the operations health route", async () => {
-    const fetchMock = vi.fn(async () =>
-      new Response(JSON.stringify({ data: { status: "ok", timestamp: "2026-06-03T00:00:00.000Z", version: "3.0.0" } })),
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: { status: "ok", timestamp: "2026-06-03T00:00:00.000Z", version: "3.0.0" },
+          }),
+        ),
     );
     const client = createClient({ baseUrl: "https://metrics.example", fetch: fetchMock });
 
@@ -132,8 +137,12 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expectTypeOf(await client.query({ operationName: "latest/metrics" })).toEqualTypeOf<
       Operations["latest/metrics"]["response"]
     >();
-    expectTypeOf(protocolMetrics).toEqualTypeOf<Operations["paginated/protocolMetrics"]["response"]>();
-    expectTypeOf(protocolMetrics).toEqualTypeOf<WundergraphResponse<Operations["paginated/protocolMetrics"]["data"]>>();
+    expectTypeOf(protocolMetrics).toEqualTypeOf<
+      Operations["paginated/protocolMetrics"]["response"]
+    >();
+    expectTypeOf(protocolMetrics).toEqualTypeOf<
+      WundergraphResponse<Operations["paginated/protocolMetrics"]["data"]>
+    >();
   });
 
   test("deprecated legacy helper methods call the same operations routes", async () => {
@@ -193,7 +202,10 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
         { start: "2025-01-04", end: "2025-01-04" },
       ],
     },
-  ])("auto-paginates v2 daily metrics when the date range is $label", async ({ end, expectedChunks }) => {
+  ])("auto-paginates v2 daily metrics when the date range is $label", async ({
+    end,
+    expectedChunks,
+  }) => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const parsed = new URL(input instanceof Request ? input.url : input.toString());
       if (parsed.pathname === "/v2/bounds") {
@@ -327,11 +339,19 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
           }),
         );
       }
-      return new Response(JSON.stringify({ data: [{ path: parsed.pathname, start: parsed.searchParams.get("start") }] }));
+      return new Response(
+        JSON.stringify({
+          data: [{ path: parsed.pathname, start: parsed.searchParams.get("start") }],
+        }),
+      );
     });
     const client = createClient({ baseUrl: "https://metrics.example", fetch: fetchMock });
 
-    await client.getDailyTreasuryAssets({ start: "2025-01-01", end: "2025-01-03", autoPaginate: true });
+    await client.getDailyTreasuryAssets({
+      start: "2025-01-01",
+      end: "2025-01-03",
+      autoPaginate: true,
+    });
     await client.getDailyOhmSupply({ start: "2025-01-01", end: "2025-01-03", autoPaginate: true });
 
     const calls = fetchMock.mock.calls as unknown as Array<[string, RequestInit?]>;
@@ -375,7 +395,9 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expect(packageJson.files).toContain("CHANGELOG.md");
     expect(packageJson.files).toContain("openapi.json");
     expect(packageJson.files).toContain("dist");
-    expect(packageJson.scripts.build).toBe("rm -rf dist && tsc -p tsconfig.build.json && pnpm run openapi:generate");
+    expect(packageJson.scripts.build).toBe(
+      "rm -rf dist && tsc -p tsconfig.build.json && pnpm run openapi:generate",
+    );
     expect(packageJson.scripts["openapi:generate"]).toBe("tsx scripts/write-openapi.ts");
     expect(packageJson.scripts["pack:dry-run"]).toBe(
       "pnpm run build && npm pack --dry-run --ignore-scripts --cache /tmp/olympus-treasury-subgraph-npm-cache",
@@ -392,7 +414,10 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
   });
 
   test("ships a manual CI staged-publishing workflow", () => {
-    const workflow = readFileSync(resolve(CLIENT_DIR, "../../.github/workflows/client-release.yml"), "utf8");
+    const workflow = readFileSync(
+      resolve(CLIENT_DIR, "../../.github/workflows/client-release.yml"),
+      "utf8",
+    );
     const docs = readFileSync(resolve(CLIENT_DIR, "../../docs/client-release.md"), "utf8");
 
     expect(workflow).toContain("workflow_dispatch:");
@@ -413,12 +438,14 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expect(workflow).toContain("actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f");
     expect(workflow).toContain("node-version: 24");
     expect(workflow).toContain("npm install -g npm@11.15.0");
-    expect(workflow).toContain("pnpm --dir \"$PACKAGE_DIR\" exec tsx scripts/ci-release.ts validate");
-    expect(workflow).toContain("pnpm --dir \"$PACKAGE_DIR\" exec tsx scripts/ci-release.ts pack");
-    expect(workflow).toContain("pnpm --dir \"$PACKAGE_DIR\" exec tsx scripts/ci-release.ts notes");
-    expect(workflow).toContain("pnpm --dir \"$PACKAGE_DIR\" run release:check");
+    expect(workflow).toContain('pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts validate');
+    expect(workflow).toContain('pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts pack');
+    expect(workflow).toContain('pnpm --dir "$PACKAGE_DIR" exec tsx scripts/ci-release.ts notes');
+    expect(workflow).toContain('pnpm --dir "$PACKAGE_DIR" run release:check');
     expect(workflow).toContain("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a");
-    expect(workflow).toContain("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c");
+    expect(workflow).toContain(
+      "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    );
     const githubReleaseJobIndex = workflow.indexOf("github-release:");
     const githubReleaseCheckoutIndex = workflow.indexOf(
       "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
@@ -430,7 +457,7 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expect(workflow).toContain(`if: \${{ inputs.mode == 'dry-run' }}`);
     expect(workflow).toContain(`if: \${{ inputs.mode == 'stage' }}`);
     expect(workflow).toContain("No npm staging, git tag, or GitHub Release was created.");
-    expect(workflow).toContain("npm stage publish \"$RUNNER_TEMP/client-package/");
+    expect(workflow).toContain('npm stage publish "$RUNNER_TEMP/client-package/');
     expect(workflow).toContain("gh release create");
     expect(workflow).not.toContain("npm publish --access public");
     expect(workflow).not.toContain("NODE_AUTH_TOKEN");
@@ -468,7 +495,7 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expect(ciRelease).toContain('"release"');
     expect(ciRelease).toContain('"create"');
     expect(ciRelease).toContain('"tag"');
-    expect(ciRelease).toContain('getExitStatus(error) !== 2');
+    expect(ciRelease).toContain("getExitStatus(error) !== 2");
     expect(docs).toContain("Use the manual GitHub Actions workflow");
     expect(docs).toContain("Allow **stage publish**");
     expect(docs).toContain("Do not allow direct");
@@ -494,7 +521,9 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     expect(notes).toContain("## Changelog");
     expect(notes).toContain("## [v3.0.0] - 2026-06-04");
     expect(notes).toContain("### Breaking: Move to the self-hosted metrics API");
-    expect(notes).toContain("Preserved legacy `query({ operationName, input })` support for `/operations/*`.");
+    expect(notes).toContain(
+      "Preserved legacy `query({ operationName, input })` support for `/operations/*`.",
+    );
     expect(notes).not.toContain("## [v2.0.0]");
   });
 
@@ -502,8 +531,10 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
     const releaseCheck = readFileSync(clientFile("scripts/release-check.ts"), "utf8");
     const buildIndex = releaseCheck.indexOf('run("pnpm", ["run", "build"], packageDir);');
     const testIndex = releaseCheck.indexOf('run("pnpm", ["run", "test"], packageDir);');
-    const postBuildCleanIndex = releaseCheck.indexOf('assertCleanGitTree();', testIndex);
-    const auditIndex = releaseCheck.indexOf('run("pnpm", ["audit", "--audit-level", "moderate"], repoRoot);');
+    const postBuildCleanIndex = releaseCheck.indexOf("assertCleanGitTree();", testIndex);
+    const auditIndex = releaseCheck.indexOf(
+      'run("pnpm", ["audit", "--audit-level", "moderate"], repoRoot);',
+    );
 
     expect(buildIndex).toBeGreaterThan(0);
     expect(testIndex).toBeGreaterThan(buildIndex);
@@ -520,8 +551,12 @@ describe("@olympusdao/treasury-subgraph-client compatibility", () => {
 
     expect(packaged.openapi).toBe("3.1.0");
     expect(Object.keys(packaged.paths).sort()).toEqual(Object.keys(canonical.paths).sort());
-    expect(Object.keys(getOpenApiDocument().paths).sort()).toEqual(Object.keys(canonical.paths).sort());
-    expect(packaged.paths["/operations/paginated/metrics"]).toEqual(canonical.paths["/operations/paginated/metrics"]);
+    expect(Object.keys(getOpenApiDocument().paths).sort()).toEqual(
+      Object.keys(canonical.paths).sort(),
+    );
+    expect(packaged.paths["/operations/paginated/metrics"]).toEqual(
+      canonical.paths["/operations/paginated/metrics"],
+    );
   });
 
   test("exports semantic v2 and legacy-compatible TypeScript types", () => {

--- a/apps/indexer/src/effects/index.ts
+++ b/apps/indexer/src/effects/index.ts
@@ -902,9 +902,7 @@ export const readBlockTimestamp = createEffect(
     const config = CHAIN_CONFIGS[input.chainId as ChainId];
     if (!config) throw new Error(`Unsupported chain ${input.chainId}`);
     const client = getClient(config);
-    const block = await retryRpc(() =>
-      client.getBlock({ blockNumber: BigInt(input.blockNumber) }),
-    );
+    const block = await retryRpc(() => client.getBlock({ blockNumber: BigInt(input.blockNumber) }));
     return Number(block.timestamp);
   },
 );

--- a/apps/indexer/src/handlers/BlockHandlers.ts
+++ b/apps/indexer/src/handlers/BlockHandlers.ts
@@ -1,11 +1,5 @@
 import BigNumberCtor, { type default as BigNumber } from "bignumber.js";
 import {
-  aggregateAcrossChains,
-  computeApy,
-  computeDerivedRatios,
-  computePerChainAggregate,
-} from "../snapshot/global";
-import {
   BigDecimal,
   type EvmOnBlockContext,
   indexer,
@@ -13,11 +7,7 @@ import {
   type TokenSupply,
 } from "envio";
 import type { PublicClient } from "viem";
-import {
-  readBlockTimestamp,
-  readNextOhmDistribution,
-  readSOhmCirculatingSupply,
-} from "../effects";
+import { readBlockTimestamp, readNextOhmDistribution, readSOhmCirculatingSupply } from "../effects";
 import {
   getPrice,
   getTotalValue,
@@ -27,7 +17,12 @@ import {
 } from "../pricing";
 import { CHAIN_CONFIGS } from "../snapshot/chains";
 import { withContractReadCache } from "../snapshot/contract-cache";
-import { getClient } from "../snapshot/rpc-client";
+import {
+  aggregateAcrossChains,
+  computeApy,
+  computeDerivedRatios,
+  computePerChainAggregate,
+} from "../snapshot/global";
 import {
   addr,
   getTokenDecimals,
@@ -44,6 +39,7 @@ import {
   getTokenDefinition,
   getWalletAddressesForContract,
 } from "../snapshot/records";
+import { getClient } from "../snapshot/rpc-client";
 import {
   CHAIN_IDS,
   type ChainConfig,
@@ -471,7 +467,19 @@ export async function updateGlobalMetricSnapshot(
 // for snapshot-pipeline simplicity) to the SupplyCategoryType GraphQL enum
 // members. If a TYPE_* string is missing from this map, the writer above
 // skips the row rather than emit a value the GraphQL enum would reject.
-const CATEGORY_TYPE_TO_ENUM: Record<string, "TOTAL_SUPPLY" | "TREASURY" | "OHM_MIGRATION_OFFSET" | "BONDS_PREMINTED" | "BONDS_VESTING_DEPOSITS" | "BONDS_VESTING_TOKENS" | "BONDS_DEPOSITS" | "LIQUIDITY" | "BOOSTED_LIQUIDITY_VAULT" | "LENDING"> = {
+const CATEGORY_TYPE_TO_ENUM: Record<
+  string,
+  | "TOTAL_SUPPLY"
+  | "TREASURY"
+  | "OHM_MIGRATION_OFFSET"
+  | "BONDS_PREMINTED"
+  | "BONDS_VESTING_DEPOSITS"
+  | "BONDS_VESTING_TOKENS"
+  | "BONDS_DEPOSITS"
+  | "LIQUIDITY"
+  | "BOOSTED_LIQUIDITY_VAULT"
+  | "LENDING"
+> = {
   "Total Supply": "TOTAL_SUPPLY",
   Treasury: "TREASURY",
   "OHM Migration Offset": "OHM_MIGRATION_OFFSET",
@@ -611,8 +619,6 @@ async function pushOwnedLiquidityRecords(
     }
   }
 }
-
-
 
 // ----- Token supplies (OHM total / treasury / liquidity / lending) -----
 

--- a/apps/indexer/src/handlers/KodiakLps.ts
+++ b/apps/indexer/src/handlers/KodiakLps.ts
@@ -5,8 +5,8 @@ import { resolveKodiakUnderlyingPool } from "../effects";
 import { KODIAK_ABI } from "../snapshot/abis/kodiak";
 import { CHAIN_CONFIGS } from "../snapshot/chains";
 import { readInvariantContract } from "../snapshot/contract-cache";
-import { getClient } from "../snapshot/rpc-client";
 import { addr } from "../snapshot/math";
+import { getClient } from "../snapshot/rpc-client";
 import type { ChainId } from "../snapshot/types";
 import { buildLpTransferWhere, handleLpTransfer } from "./Erc20Transfers";
 

--- a/apps/indexer/src/handlers/SOhmV3.ts
+++ b/apps/indexer/src/handlers/SOhmV3.ts
@@ -1,4 +1,4 @@
-import { type OhmIndexState, type OhmIndexUpdate, indexer } from "envio";
+import { indexer, type OhmIndexState, type OhmIndexUpdate } from "envio";
 
 import { CHAIN_CONFIGS } from "../snapshot/chains";
 import { addr } from "../snapshot/math";

--- a/apps/indexer/src/handlers/SnapshotHelpers.ts
+++ b/apps/indexer/src/handlers/SnapshotHelpers.ts
@@ -3,8 +3,8 @@ import type { EvmOnBlockContext, NativeBalanceState } from "envio";
 import { getAddress, type PublicClient } from "viem";
 
 import { readErc20BalanceOf } from "../effects";
-import { getNativeBalance } from "../snapshot/rpc-client";
 import { addr, toDecimal, ZERO } from "../snapshot/math";
+import { getNativeBalance } from "../snapshot/rpc-client";
 import type { LiquidityHandler } from "../snapshot/types";
 
 // Shared balance-read helpers used by the snapshot block handler and the

--- a/apps/indexer/src/handlers/Univ3NftPol.ts
+++ b/apps/indexer/src/handlers/Univ3NftPol.ts
@@ -1,5 +1,5 @@
-import type { EvmOnBlockContext } from "envio";
 import BigNumber from "bignumber.js";
+import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 
 import { snapshotUniv3NftPositions } from "../effects";
@@ -7,11 +7,7 @@ import { getPrice } from "../pricing";
 import { TYPE_LIQUIDITY } from "../snapshot/global";
 import { addr, getTokenDecimals, toDecimal, univ3PositionAmounts, ZERO } from "../snapshot/math";
 import { createTokenRecord, createTokenSupply, getContractName } from "../snapshot/records";
-import type {
-  ChainConfig,
-  SerializedTokenRecord,
-  SerializedTokenSupply,
-} from "../snapshot/types";
+import type { ChainConfig, SerializedTokenRecord, SerializedTokenSupply } from "../snapshot/types";
 
 // UniV3 NFT POL. For each treasury wallet, walk its NonfungiblePositionManager
 // NFT holdings, match each position to a known UniV3 pricing pool, compute

--- a/apps/indexer/src/pricing/index.ts
+++ b/apps/indexer/src/pricing/index.ts
@@ -136,9 +136,7 @@ async function derivePrice(
 // share the same underlying `pool`; every other kind uses `id` as its pool
 // identity.
 function underlyingPool(handler: LiquidityHandler): string {
-  return "pool" in handler && handler.pool
-    ? handler.pool.toLowerCase()
-    : handler.id.toLowerCase();
+  return "pool" in handler && handler.pool ? handler.pool.toLowerCase() : handler.id.toLowerCase();
 }
 
 export async function getTotalValue(

--- a/apps/indexer/src/pricing/kodiak.ts
+++ b/apps/indexer/src/pricing/kodiak.ts
@@ -39,9 +39,7 @@ function applyDecimalAdjustment(
   const diff = lookupIsToken0 ? decimals0 - decimals1 : decimals1 - decimals0;
   const factor = new BigNumber(10).pow(Math.abs(diff));
   const decimalAdjustment = diff < 0 ? ONE.div(factor) : factor;
-  const rawTerm = lookupIsToken0
-    ? rawPriceToken0InToken1
-    : ONE.div(rawPriceToken0InToken1);
+  const rawTerm = lookupIsToken0 ? rawPriceToken0InToken1 : ONE.div(rawPriceToken0InToken1);
   return decimalAdjustment.times(rawTerm);
 }
 

--- a/apps/indexer/src/snapshot/global.ts
+++ b/apps/indexer/src/snapshot/global.ts
@@ -286,4 +286,4 @@ export function computeApy(
   return { nextEpochRebase, currentApy };
 }
 
-export { ZERO, ONE };
+export { ONE, ZERO };

--- a/apps/indexer/src/start-envio.ts
+++ b/apps/indexer/src/start-envio.ts
@@ -4,7 +4,8 @@ import { validateIndexerEnv } from "./validate-env";
 
 export function prepareIndexerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const railwayPort = env.PORT?.trim();
-  const hasEnvioIndexerPort = env.ENVIO_INDEXER_PORT !== undefined && env.ENVIO_INDEXER_PORT.trim() !== "";
+  const hasEnvioIndexerPort =
+    env.ENVIO_INDEXER_PORT !== undefined && env.ENVIO_INDEXER_PORT.trim() !== "";
   if (!hasEnvioIndexerPort && railwayPort !== undefined && railwayPort !== "") {
     env.ENVIO_INDEXER_PORT = railwayPort;
   }
@@ -25,7 +26,10 @@ export function resolveEnvioArgs(args: string[], env: NodeJS.ProcessEnv = proces
   return [...resolvedArgs, "-r"];
 }
 
-export function runIndexerStartup(args: string[] = process.argv.slice(2), env: NodeJS.ProcessEnv = process.env): void {
+export function runIndexerStartup(
+  args: string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): void {
   const preparedEnv = prepareIndexerEnv(env);
   validateIndexerEnv(preparedEnv);
 

--- a/apps/indexer/src/validate-env.ts
+++ b/apps/indexer/src/validate-env.ts
@@ -40,27 +40,39 @@ export function validateIndexerEnv(env: NodeJS.ProcessEnv): void {
     throw new Error(`Invalid URL environment variables: ${invalidUrls.join(", ")}`);
   }
 
-  const invalidIntegers = POSITIVE_INTEGER_ENV_VARS.filter((name) => !isPositiveInteger(env[name] ?? ""));
+  const invalidIntegers = POSITIVE_INTEGER_ENV_VARS.filter(
+    (name) => !isPositiveInteger(env[name] ?? ""),
+  );
   if (invalidIntegers.length > 0) {
-    throw new Error(`Invalid positive integer environment variables: ${invalidIntegers.join(", ")}`);
+    throw new Error(
+      `Invalid positive integer environment variables: ${invalidIntegers.join(", ")}`,
+    );
   }
 
   const invalidOptionalIntegers = OPTIONAL_POSITIVE_INTEGER_ENV_VARS.filter(
     (name) => !isBlank(env[name]) && !isPositiveInteger(env[name] ?? ""),
   );
   if (invalidOptionalIntegers.length > 0) {
-    throw new Error(`Invalid positive integer environment variables: ${invalidOptionalIntegers.join(", ")}`);
+    throw new Error(
+      `Invalid positive integer environment variables: ${invalidOptionalIntegers.join(", ")}`,
+    );
   }
 
   if (isRailwayRuntime(env) && !isBlank(env.ENVIO_PG_SCHEMA)) {
-    throw new Error("ENVIO_PG_SCHEMA must not be set on Railway; Envio must use its default schema.");
+    throw new Error(
+      "ENVIO_PG_SCHEMA must not be set on Railway; Envio must use its default schema.",
+    );
   }
 
   if (isRailwayRuntime(env) && isBlank(env.PORT)) {
     throw new Error("PORT must be set when running on Railway.");
   }
 
-  if (!isBlank(env.PORT) && !isBlank(env.ENVIO_INDEXER_PORT) && env.PORT !== env.ENVIO_INDEXER_PORT) {
+  if (
+    !isBlank(env.PORT) &&
+    !isBlank(env.ENVIO_INDEXER_PORT) &&
+    env.PORT !== env.ENVIO_INDEXER_PORT
+  ) {
     throw new Error("ENVIO_INDEXER_PORT must match PORT when PORT is set.");
   }
 }

--- a/apps/indexer/tests/env.test.ts
+++ b/apps/indexer/tests/env.test.ts
@@ -123,12 +123,12 @@ describe("indexer env validation", () => {
   });
 
   test("formats spawn failures loudly before Envio starts", () => {
-    expect(formatEnvioSpawnError(Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" }))).toContain(
-      "envio binary was not found in PATH",
-    );
-    expect(formatEnvioSpawnError(Object.assign(new Error("permission denied"), { code: "EACCES" }))).toBe(
-      "Failed to start envio: EACCES: permission denied",
-    );
+    expect(
+      formatEnvioSpawnError(Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" })),
+    ).toContain("envio binary was not found in PATH");
+    expect(
+      formatEnvioSpawnError(Object.assign(new Error("permission denied"), { code: "EACCES" })),
+    ).toBe("Failed to start envio: EACCES: permission denied");
   });
 
   test("attaches a spawn error handler that logs and exits", () => {
@@ -151,9 +151,9 @@ describe("indexer env validation", () => {
     });
 
     expect(handlers.has("error")).toBe(true);
-    expect(() => handlers.get("error")?.(Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" }))).toThrow(
-      "exit 1",
-    );
+    expect(() =>
+      handlers.get("error")?.(Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" })),
+    ).toThrow("exit 1");
     expect(logged[0]).toContain("envio binary was not found in PATH");
     expect(exits).toEqual([1]);
   });

--- a/apps/indexer/tests/handlers/ArbitrumStaking.test.ts
+++ b/apps/indexer/tests/handlers/ArbitrumStaking.test.ts
@@ -6,8 +6,8 @@ vi.mock("../../src/pricing", () => ({
   getPrice: vi.fn(),
 }));
 
-import { getPrice } from "../../src/pricing";
 import { pushArbitrumStakingRecords } from "../../src/handlers/ArbitrumStaking";
+import { getPrice } from "../../src/pricing";
 import { ARBITRUM, ERC20_MAGIC } from "../../src/snapshot/chains/arbitrum";
 import type { SerializedTokenRecord } from "../../src/snapshot/types";
 

--- a/apps/indexer/tests/handlers/BackfillTokenBalances.live.test.ts
+++ b/apps/indexer/tests/handlers/BackfillTokenBalances.live.test.ts
@@ -31,15 +31,12 @@ describe.skipIf(!hasApiToken)("BackfillTokenBalances — live HyperSync (post-fi
         42161: { startBlock: 10_950_000, endBlock: 10_950_500 },
       },
     });
-    const backfillRows = result.changes.flatMap(
-      (change) =>
-        (change.TokenBalanceUpdate?.sets ?? []).filter((row) =>
-          String((row as { id: string }).id).endsWith("-backfill"),
-        ),
+    const backfillRows = result.changes.flatMap((change) =>
+      (change.TokenBalanceUpdate?.sets ?? []).filter((row) =>
+        String((row as { id: string }).id).endsWith("-backfill"),
+      ),
     );
-    const sentinelRows = result.changes.flatMap(
-      (change) => change.BackfillSentinel?.sets ?? [],
-    );
+    const sentinelRows = result.changes.flatMap((change) => change.BackfillSentinel?.sets ?? []);
     expect(backfillRows.length).toBeGreaterThan(0);
     expect(sentinelRows).toHaveLength(1);
     expect((sentinelRows[0] as { chainId: number }).chainId).toBe(42161);
@@ -52,9 +49,7 @@ describe.skipIf(!hasApiToken)("BackfillTokenBalances — live HyperSync (post-fi
         80094: { startBlock: 799_194, endBlock: 1_341_000 },
       },
     });
-    const sentinelRows = result.changes.flatMap(
-      (change) => change.BackfillSentinel?.sets ?? [],
-    );
+    const sentinelRows = result.changes.flatMap((change) => change.BackfillSentinel?.sets ?? []);
     // The fix proves itself: sentinel exists ⇒ handler fired exactly once.
     // (Berachain may have zero non-zero pre-window balances, so we don't
     // assert on TokenBalanceUpdate-backfill row count — only on the

--- a/apps/indexer/tests/handlers/BackfillTokenBalances.test.ts
+++ b/apps/indexer/tests/handlers/BackfillTokenBalances.test.ts
@@ -82,9 +82,7 @@ describe("BackfillTokenBalances", () => {
     expect(result.seeded).toBeGreaterThanOrEqual(1);
     const fraxEntity = tokenBalanceSets.find(
       (e) =>
-        e.tokenAddress === addr(FRAX) &&
-        e.walletAddress === addr(wallet) &&
-        e.chainId === 42161,
+        e.tokenAddress === addr(FRAX) && e.walletAddress === addr(wallet) && e.chainId === 42161,
     );
     expect(fraxEntity).toBeDefined();
     expect(fraxEntity?.balance).toBe(PRE_EXISTING);
@@ -93,9 +91,7 @@ describe("BackfillTokenBalances", () => {
 
     const fraxUpdate = tokenBalanceUpdateSets.find(
       (e) =>
-        e.tokenAddress === addr(FRAX) &&
-        e.walletAddress === addr(wallet) &&
-        e.chainId === 42161,
+        e.tokenAddress === addr(FRAX) && e.walletAddress === addr(wallet) && e.chainId === 42161,
     );
     expect(fraxUpdate).toBeDefined();
     expect(fraxUpdate?.delta).toBe(PRE_EXISTING);
@@ -128,7 +124,9 @@ describe("BackfillTokenBalances", () => {
       chainId: 42161,
       blockTimestamp: 1_651_363_200,
       // Even if "native" had a seed, runBackfill should skip native tokens
-      balances: [{ tokenAddress: NATIVE, walletAddress: wallet, balance: 5_000_000_000_000_000_000n }],
+      balances: [
+        { tokenAddress: NATIVE, walletAddress: wallet, balance: 5_000_000_000_000_000_000n },
+      ],
     });
 
     await runBackfill(context, { number: 10_950_000 });

--- a/apps/indexer/tests/handlers/BlockHandlers.test.ts
+++ b/apps/indexer/tests/handlers/BlockHandlers.test.ts
@@ -1,10 +1,6 @@
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test, vi } from "vitest";
-
-import { CHAIN_CONFIGS } from "../../src/snapshot/chains";
-import { addr } from "../../src/snapshot/math";
-import type { SerializedTokenRecord, SerializedTokenSupply } from "../../src/snapshot/types";
 import {
   BLOCK_HANDLERS,
   pushTokenBalanceRecords,
@@ -12,6 +8,9 @@ import {
   pushTreasuryOhm,
   updateGlobalMetricSnapshot,
 } from "../../src/handlers/BlockHandlers";
+import { CHAIN_CONFIGS } from "../../src/snapshot/chains";
+import { addr } from "../../src/snapshot/math";
+import type { SerializedTokenRecord, SerializedTokenSupply } from "../../src/snapshot/types";
 
 // Per-chain snapshot validation. Each test wires a minimal mock context
 // with one TokenBalance + ChainlinkPriceState row, calls
@@ -313,7 +312,11 @@ describe("pushTokenBalanceRecords per-chain validation", () => {
 
     // Three rows: OHM, gOHM, sOHM V3 (no sOHM V2 balance seeded, so it's
     // not emitted even though the gate is satisfied).
-    const byToken = new Map(supplies.filter((s) => s.source === wallet || s.sourceAddress === wallet).map((s) => [s.token, s]));
+    const byToken = new Map(
+      supplies
+        .filter((s) => s.source === wallet || s.sourceAddress === wallet)
+        .map((s) => [s.token, s]),
+    );
     expect(byToken.get("OHM")?.supplyBalance).toBe("-100"); // OHM v2 raw
     expect(byToken.get("Governance OHM (gOHM)")?.supplyBalance).toBe("-1065"); // 5 × 213 = 1065 OHM-equiv
     expect(byToken.get("Staked OHM V3 (sOHM)")?.supplyBalance).toBe("-50"); // sOHM v3 direct

--- a/apps/indexer/tests/handlers/BondManager.test.ts
+++ b/apps/indexer/tests/handlers/BondManager.test.ts
@@ -1,9 +1,4 @@
-import type {
-  BigDecimal,
-  EvmOnEventContext,
-  GnosisAuction,
-  GnosisAuctionRoot,
-} from "envio";
+import type { BigDecimal, EvmOnEventContext, GnosisAuction, GnosisAuctionRoot } from "envio";
 import { describe, expect, test, vi } from "vitest";
 
 import { applyGnosisAuctionLaunched } from "../../src/handlers/BondManager";

--- a/apps/indexer/tests/handlers/Erc4626Vault.test.ts
+++ b/apps/indexer/tests/handlers/Erc4626Vault.test.ts
@@ -1,14 +1,16 @@
 import type { TokenBalance, TokenBalanceUpdate } from "envio";
 import { describe, expect, test, vi } from "vitest";
 
-import {
-  handleErc4626Deposit,
-  handleErc4626Withdraw,
-} from "../../src/handlers/Erc20Transfers";
+import { handleErc4626Deposit, handleErc4626Withdraw } from "../../src/handlers/Erc20Transfers";
 import { CHAIN_CONFIGS } from "../../src/snapshot/chains";
 import { addr } from "../../src/snapshot/math";
 
-function buildContext(seed?: { tokenAddress: string; walletAddress: string; balance: bigint; chainId: number }) {
+function buildContext(seed?: {
+  tokenAddress: string;
+  walletAddress: string;
+  balance: bigint;
+  chainId: number;
+}) {
   const tokenBalances = new Map<string, TokenBalance>();
   if (seed) {
     const id = `${seed.chainId}-${addr(seed.tokenAddress)}-${addr(seed.walletAddress)}`;
@@ -88,7 +90,13 @@ describe("Erc4626Vault handlers", () => {
         srcAddress: SDAI,
         logIndex: 50,
         block: { number: 18_500_000, timestamp: 1_700_000_000 },
-        params: { sender: DAO_MS, receiver: DAO_MS, owner: TRSRY, assets: assetsOut, shares: sharesBurnt },
+        params: {
+          sender: DAO_MS,
+          receiver: DAO_MS,
+          owner: TRSRY,
+          assets: assetsOut,
+          shares: sharesBurnt,
+        },
       },
       context: context as unknown as Parameters<typeof handleErc4626Withdraw>[0]["context"],
     });
@@ -136,7 +144,12 @@ describe("Erc4626Vault handlers", () => {
         srcAddress: SDAI,
         logIndex: 1,
         block: { number: 18_164_221, timestamp: 1_695_000_000 },
-        params: { sender: DAO_MS, owner: randomOwner, assets: 1_000_000_000_000_000_000n, shares: 1_000_000_000_000_000_000n },
+        params: {
+          sender: DAO_MS,
+          owner: randomOwner,
+          assets: 1_000_000_000_000_000_000n,
+          shares: 1_000_000_000_000_000_000n,
+        },
       },
       context: context as unknown as Parameters<typeof handleErc4626Deposit>[0]["context"],
     });
@@ -154,7 +167,13 @@ describe("Erc4626Vault handlers", () => {
         srcAddress: SDAI,
         logIndex: 1,
         block: { number: 18_500_000, timestamp: 1_700_000_000 },
-        params: { sender: DAO_MS, receiver: DAO_MS, owner: randomOwner, assets: 1_000_000_000_000_000_000n, shares: 1_000_000_000_000_000_000n },
+        params: {
+          sender: DAO_MS,
+          receiver: DAO_MS,
+          owner: randomOwner,
+          assets: 1_000_000_000_000_000_000n,
+          shares: 1_000_000_000_000_000_000n,
+        },
       },
       context: context as unknown as Parameters<typeof handleErc4626Withdraw>[0]["context"],
     });

--- a/apps/indexer/tests/handlers/StakingRewardsVault.test.ts
+++ b/apps/indexer/tests/handlers/StakingRewardsVault.test.ts
@@ -8,7 +8,12 @@ import {
 import { CHAIN_CONFIGS } from "../../src/snapshot/chains";
 import { addr } from "../../src/snapshot/math";
 
-function buildContext(seed?: { tokenAddress: string; walletAddress: string; balance: bigint; chainId: number }) {
+function buildContext(seed?: {
+  tokenAddress: string;
+  walletAddress: string;
+  balance: bigint;
+  chainId: number;
+}) {
   const tokenBalances = new Map<string, TokenBalance>();
   if (seed) {
     const id = `${seed.chainId}-${addr(seed.tokenAddress)}-${addr(seed.walletAddress)}`;

--- a/apps/indexer/tests/handlers/Wrapped9.test.ts
+++ b/apps/indexer/tests/handlers/Wrapped9.test.ts
@@ -1,16 +1,18 @@
 import type { TokenBalance, TokenBalanceUpdate } from "envio";
 import { describe, expect, test, vi } from "vitest";
 
-import {
-  handleWrapped9Deposit,
-  handleWrapped9Withdrawal,
-} from "../../src/handlers/Erc20Transfers";
+import { handleWrapped9Deposit, handleWrapped9Withdrawal } from "../../src/handlers/Erc20Transfers";
 import { CHAIN_CONFIGS } from "../../src/snapshot/chains";
 import { addr } from "../../src/snapshot/math";
 
 // Mock context that records TokenBalance + TokenBalanceUpdate writes and
 // returns a seeded TokenBalance for the relevant id on read.
-function buildContext(seed?: { tokenAddress: string; walletAddress: string; balance: bigint; chainId: number }) {
+function buildContext(seed?: {
+  tokenAddress: string;
+  walletAddress: string;
+  balance: bigint;
+  chainId: number;
+}) {
   const tokenBalances = new Map<string, TokenBalance>();
   if (seed) {
     const id = `${seed.chainId}-${addr(seed.tokenAddress)}-${addr(seed.walletAddress)}`;

--- a/apps/indexer/tests/pricing/curve.test.ts
+++ b/apps/indexer/tests/pricing/curve.test.ts
@@ -1,9 +1,8 @@
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test, vi } from "vitest";
-
-import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 import { getPrice } from "../../src/pricing";
+import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 
 const CHAIN_ID = 1;
 const POOL = "0xfc1e8bf3e81383ef07be24c3fd146745719de48d";

--- a/apps/indexer/tests/pricing/erc4626.test.ts
+++ b/apps/indexer/tests/pricing/erc4626.test.ts
@@ -2,9 +2,8 @@ import BigNumber from "bignumber.js";
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test, vi } from "vitest";
-
-import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 import { getPrice } from "../../src/pricing";
+import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 
 const CHAIN_ID = 1;
 const SDAI = "0x83f20f44975d03b1b09e64809b757c47f942beea";

--- a/apps/indexer/tests/pricing/fraxswap.test.ts
+++ b/apps/indexer/tests/pricing/fraxswap.test.ts
@@ -1,9 +1,8 @@
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test, vi } from "vitest";
-
-import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 import { getPrice } from "../../src/pricing";
+import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 
 const CHAIN_ID = 1;
 const POOL = "0x38633ed142bcc8128b45ab04a2e4a6e53774699f";

--- a/apps/indexer/tests/pricing/gohm.test.ts
+++ b/apps/indexer/tests/pricing/gohm.test.ts
@@ -2,9 +2,8 @@ import BigNumber from "bignumber.js";
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test } from "vitest";
-
-import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 import { getPrice } from "../../src/pricing";
+import type { ChainConfig, LiquidityHandler } from "../../src/snapshot/types";
 
 const CHAIN_ID = 1;
 const SOHM_V3 = "0x04906695d6d12cf5459975d7c3c03356e4ccd460";

--- a/apps/indexer/tests/pricing/router.test.ts
+++ b/apps/indexer/tests/pricing/router.test.ts
@@ -1,9 +1,8 @@
 import type { EvmOnBlockContext } from "envio";
 import type { PublicClient } from "viem";
 import { describe, expect, test } from "vitest";
-
-import type { ChainConfig, LiquidityHandler, TokenDefinition } from "../../src/snapshot/types";
 import { getPrice, withPricingCache } from "../../src/pricing";
+import type { ChainConfig, LiquidityHandler, TokenDefinition } from "../../src/snapshot/types";
 
 // Synthetic test fixtures so the cycle / recursion guards can be exercised
 // in isolation from any chain's real config. The router lives in

--- a/apps/indexer/tests/snapshot/math.test.ts
+++ b/apps/indexer/tests/snapshot/math.test.ts
@@ -58,7 +58,9 @@ describe("toBigDecimal", () => {
       },
     } as BigNumber;
 
-    expect(toBigDecimal(value).toString()).toBe(new BigNumber("123456789012345678901234567890").toString());
+    expect(toBigDecimal(value).toString()).toBe(
+      new BigNumber("123456789012345678901234567890").toString(),
+    );
     expect(fixedCalls).toBe(1);
     expect(stringCalls).toBe(0);
   });

--- a/apps/indexer/tests/snapshot/pricing.test.ts
+++ b/apps/indexer/tests/snapshot/pricing.test.ts
@@ -555,7 +555,9 @@ describe("Berachain Envio snapshot parity", () => {
         block,
       );
       if (totalValue === null || includedValue === null) {
-        throw new Error("Expected Beradrome total values to resolve after base Kodiak cache priming");
+        throw new Error(
+          "Expected Beradrome total values to resolve after base Kodiak cache priming",
+        );
       }
       const multiplier = includedValue.div(totalValue);
       expect(multiplier.lt(1)).toBe(true);

--- a/apps/metrics-api/src/server.ts
+++ b/apps/metrics-api/src/server.ts
@@ -1,23 +1,22 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-
-import { ArtifactNotFoundError, type ArtifactReader } from "./artifact-store";
 import {
   ALL_CHAIN_IDS,
-  buildDailyMetric,
-  getOpenApiDocument,
-  isCrossChainComplete,
-  monthKeysForRange,
-  resolveDateRange,
   type ApiErrorResponse,
   type ApiResponse,
   type BoundsResponse,
+  buildDailyMetric,
   type DailyMetric,
+  getOpenApiDocument,
+  isCrossChainComplete,
   type Manifest,
+  monthKeysForRange,
   type OhmSupply,
   type ProtocolMetric,
+  resolveDateRange,
   type TreasuryAsset,
   type WundergraphResponse,
 } from "../../../packages/metrics-artifacts/src";
+import { ArtifactNotFoundError, type ArtifactReader } from "./artifact-store";
 
 export type MetricsApiConfig = {
   maxRangeDays: number;
@@ -81,7 +80,13 @@ function setCommonHeaders(res: ServerResponse): void {
   res.setHeader("vary", "origin");
 }
 
-function sendBody(req: IncomingMessage, res: ServerResponse, status: number, contentType: string, body: string): void {
+function sendBody(
+  req: IncomingMessage,
+  res: ServerResponse,
+  status: number,
+  contentType: string,
+  body: string,
+): void {
   res.statusCode = status;
   res.setHeader("content-type", contentType);
   if (req.method === "HEAD") {
@@ -136,7 +141,9 @@ function validateQueryParams(url: URL): { code: string; message: string } | unde
   }
 
   const supportedKeySet = new Set(supportedKeys);
-  const unsupportedKeys = Array.from(new Set([...url.searchParams.keys()].filter((key) => !supportedKeySet.has(key))));
+  const unsupportedKeys = Array.from(
+    new Set([...url.searchParams.keys()].filter((key) => !supportedKeySet.has(key))),
+  );
   if (unsupportedKeys.length > 0) {
     return {
       code: "unsupported_query_parameter",
@@ -273,7 +280,9 @@ async function readArtifactRows<T>(
   const rows: T[] = [];
   for (const month of monthKeysForRange(range)) {
     try {
-      const monthRows = await config.artifactReader.getJson<T[]>(artifactKeyForMonth(manifest, keyPrefix, month));
+      const monthRows = await config.artifactReader.getJson<T[]>(
+        artifactKeyForMonth(manifest, keyPrefix, month),
+      );
       rows.push(...monthRows.filter((row) => isInRange((row as { date: string }).date, range)));
     } catch (error) {
       if (!(error instanceof ArtifactNotFoundError)) {
@@ -284,7 +293,9 @@ async function readArtifactRows<T>(
   return rows;
 }
 
-async function readSelectedDailyRecords<T extends { date: string; block: number; blockchain: string }>(
+async function readSelectedDailyRecords<
+  T extends { date: string; block: number; blockchain: string },
+>(
   config: MetricsApiConfig,
   manifest: Manifest,
   range: { start: string; end: string; days: number },
@@ -328,12 +339,20 @@ function isSelectedMetricBlock(
   metric: DailyMetric,
   record: { block: number; blockchain: string },
 ): boolean {
-  const metricBlock = (metric.blocks as Partial<Record<string, number>> | undefined)?.[record.blockchain];
+  const metricBlock = (metric.blocks as Partial<Record<string, number>> | undefined)?.[
+    record.blockchain
+  ];
   return metricBlock !== undefined && metricBlock !== 0 && Number(record.block) === metricBlock;
 }
 
-function attachMetricRecords(metric: DailyMetric, treasuryAssets: TreasuryAsset[], ohmSupply: OhmSupply[]): DailyMetric {
-  const selectedTreasuryAssets = treasuryAssets.filter((asset) => isSelectedMetricBlock(metric, asset));
+function attachMetricRecords(
+  metric: DailyMetric,
+  treasuryAssets: TreasuryAsset[],
+  ohmSupply: OhmSupply[],
+): DailyMetric {
+  const selectedTreasuryAssets = treasuryAssets.filter((asset) =>
+    isSelectedMetricBlock(metric, asset),
+  );
   const selectedOhmSupply = ohmSupply.filter((supply) => isSelectedMetricBlock(metric, supply));
   const records = buildDailyMetric({
     date: metric.date,
@@ -363,8 +382,15 @@ async function readDailyMetrics(
   includeRecords: boolean,
   generatedAt: string,
 ): Promise<DailyMetric[]> {
-  const metricRows = await readArtifactRows<DailyMetric>(config, manifest, range, "v2/metrics/daily");
-  const metricsByDate = new Map(metricRows.map((metric) => [metric.date, normalizeMetricCompleteness(metric)]));
+  const metricRows = await readArtifactRows<DailyMetric>(
+    config,
+    manifest,
+    range,
+    "v2/metrics/daily",
+  );
+  const metricsByDate = new Map(
+    metricRows.map((metric) => [metric.date, normalizeMetricCompleteness(metric)]),
+  );
   const treasuryAssets = includeRecords
     ? await readArtifactRows<TreasuryAsset>(config, manifest, range, "v2/treasury-assets/daily")
     : [];
@@ -418,7 +444,9 @@ function validateLegacyVariables(variables: Record<string, unknown>): Record<str
   if (unsupportedKeys.length > 0) {
     throw new Error(`Unsupported wg_variables field(s): ${unsupportedKeys.join(", ")}`);
   }
-  return Object.fromEntries(Object.entries(variables).filter(([key]) => LEGACY_VARIABLE_KEYS.has(key)));
+  return Object.fromEntries(
+    Object.entries(variables).filter(([key]) => LEGACY_VARIABLE_KEYS.has(key)),
+  );
 }
 
 function legacyString(variables: Record<string, unknown>, key: string): string | undefined {
@@ -452,8 +480,12 @@ function resolveLegacyRange(
     });
   }
 
-  const start = legacyString(variables, "startDate") ?? legacyString(variables, "start") ?? manifest.earliestDate;
-  const end = legacyString(variables, "endDate") ?? legacyString(variables, "end") ?? manifest.latestDate;
+  const start =
+    legacyString(variables, "startDate") ??
+    legacyString(variables, "start") ??
+    manifest.earliestDate;
+  const end =
+    legacyString(variables, "endDate") ?? legacyString(variables, "end") ?? manifest.latestDate;
   const requestedRange = resolveDateRange({
     start,
     end,
@@ -466,7 +498,8 @@ function resolveLegacyRange(
   }
 
   return resolveDateRange({
-    start: requestedRange.start < manifest.earliestDate ? manifest.earliestDate : requestedRange.start,
+    start:
+      requestedRange.start < manifest.earliestDate ? manifest.earliestDate : requestedRange.start,
     end: requestedRange.end > manifest.latestDate ? manifest.latestDate : requestedRange.end,
     manifest,
     maxRangeDays,
@@ -480,7 +513,8 @@ function legacyRowsDescending<T extends { date: string }>(rows: T[]): T[] {
 
 function dailyMetricToProtocolMetric(metric: DailyMetric): ProtocolMetric {
   const block = (metric.blocks as Partial<Record<string, number>> | undefined)?.Ethereum ?? 0;
-  const timestamp = (metric.timestamps as Partial<Record<string, number>> | undefined)?.Ethereum ?? 0;
+  const timestamp =
+    (metric.timestamps as Partial<Record<string, number>> | undefined)?.Ethereum ?? 0;
   const gOhmTotalSupply = metric.ohmIndex === 0 ? 0 : metric.ohmTotalSupply / metric.ohmIndex;
 
   return {
@@ -514,7 +548,12 @@ async function readLegacyOperation(
 
   if (pathname.endsWith("/tokenRecords")) {
     return legacyRowsDescending(
-      await readSelectedDailyRecords<TreasuryAsset>(config, manifest, range, "v2/treasury-assets/daily"),
+      await readSelectedDailyRecords<TreasuryAsset>(
+        config,
+        manifest,
+        range,
+        "v2/treasury-assets/daily",
+      ),
     );
   }
   if (pathname.endsWith("/tokenSupplies")) {
@@ -524,9 +563,17 @@ async function readLegacyOperation(
   }
 
   const includeRecords = variables.includeRecords === true;
-  const metrics = await readDailyMetrics(config, manifest, range, includeRecords, config.generatedAt ?? manifest.generatedAt);
+  const metrics = await readDailyMetrics(
+    config,
+    manifest,
+    range,
+    includeRecords,
+    config.generatedAt ?? manifest.generatedAt,
+  );
   const filteredMetrics =
-    variables.crossChainDataComplete === true ? metrics.filter((metric) => metric.crossChainComplete) : metrics;
+    variables.crossChainDataComplete === true
+      ? metrics.filter((metric) => metric.crossChainComplete)
+      : metrics;
   if (pathname.endsWith("/metrics") && !pathname.startsWith("/operations/paginated/")) {
     return filteredMetrics[0] === undefined
       ? buildEmptyDailyMetric({
@@ -581,7 +628,13 @@ async function handleMetricsApiRequestUnchecked(
   }
 
   if (hasRequestBody(req)) {
-    sendError(req, res, 400, "request_body_not_allowed", "GET and HEAD requests must not include a request body.");
+    sendError(
+      req,
+      res,
+      400,
+      "request_body_not_allowed",
+      "GET and HEAD requests must not include a request body.",
+    );
     return;
   }
 
@@ -611,7 +664,13 @@ async function handleMetricsApiRequestUnchecked(
   if (url.pathname === "/docs") {
     res.statusCode = 200;
     res.setHeader("cache-control", PUBLIC_CACHE_CONTROL);
-    sendBody(req, res, 200, "text/html; charset=utf-8", "<!doctype html><title>Olympus Protocol Metrics API</title><h1>OpenAPI</h1>");
+    sendBody(
+      req,
+      res,
+      200,
+      "text/html; charset=utf-8",
+      "<!doctype html><title>Olympus Protocol Metrics API</title><h1>OpenAPI</h1>",
+    );
     return;
   }
 
@@ -625,17 +684,17 @@ async function handleMetricsApiRequestUnchecked(
       return manifest;
     } catch (error) {
       if (error instanceof ArtifactNotFoundError) {
-        sendError(req, res, 503, "manifest_not_published", "Metrics artifacts have not been published yet.");
+        sendError(
+          req,
+          res,
+          503,
+          "manifest_not_published",
+          "Metrics artifacts have not been published yet.",
+        );
         return undefined;
       }
       console.error("Metrics artifact manifest is unavailable.", error);
-      sendError(
-        req,
-        res,
-        503,
-        "manifest_unavailable",
-        "Metrics artifact manifest is unavailable.",
-      );
+      sendError(req, res, 503, "manifest_unavailable", "Metrics artifact manifest is unavailable.");
       return undefined;
     }
   };
@@ -677,12 +736,23 @@ async function handleMetricsApiRequestUnchecked(
         config.generatedAt ?? publishedManifest.generatedAt,
       );
       res.setHeader("cache-control", PUBLIC_CACHE_CONTROL);
-      sendJson(req, res, 200, emptyResponse<DailyMetric[]>(config, range, metrics, publishedManifest));
+      sendJson(
+        req,
+        res,
+        200,
+        emptyResponse<DailyMetric[]>(config, range, metrics, publishedManifest),
+      );
     } catch (error) {
       if (error instanceof ArtifactNotFoundError) {
         return;
       }
-      sendError(req, res, 400, "invalid_date_range", error instanceof Error ? error.message : "Invalid date range.");
+      sendError(
+        req,
+        res,
+        400,
+        "invalid_date_range",
+        error instanceof Error ? error.message : "Invalid date range.",
+      );
     }
     return;
   }
@@ -701,12 +771,23 @@ async function handleMetricsApiRequestUnchecked(
         "v2/treasury-assets/daily",
       );
       res.setHeader("cache-control", PUBLIC_CACHE_CONTROL);
-      sendJson(req, res, 200, emptyResponse<TreasuryAsset[]>(config, range, treasuryAssets, publishedManifest));
+      sendJson(
+        req,
+        res,
+        200,
+        emptyResponse<TreasuryAsset[]>(config, range, treasuryAssets, publishedManifest),
+      );
     } catch (error) {
       if (error instanceof ArtifactNotFoundError) {
         return;
       }
-      sendError(req, res, 400, "invalid_date_range", error instanceof Error ? error.message : "Invalid date range.");
+      sendError(
+        req,
+        res,
+        400,
+        "invalid_date_range",
+        error instanceof Error ? error.message : "Invalid date range.",
+      );
     }
     return;
   }
@@ -725,12 +806,23 @@ async function handleMetricsApiRequestUnchecked(
         "v2/ohm-supply/daily",
       );
       res.setHeader("cache-control", PUBLIC_CACHE_CONTROL);
-      sendJson(req, res, 200, emptyResponse<OhmSupply[]>(config, range, ohmSupply, publishedManifest));
+      sendJson(
+        req,
+        res,
+        200,
+        emptyResponse<OhmSupply[]>(config, range, ohmSupply, publishedManifest),
+      );
     } catch (error) {
       if (error instanceof ArtifactNotFoundError) {
         return;
       }
-      sendError(req, res, 400, "invalid_date_range", error instanceof Error ? error.message : "Invalid date range.");
+      sendError(
+        req,
+        res,
+        400,
+        "invalid_date_range",
+        error instanceof Error ? error.message : "Invalid date range.",
+      );
     }
     return;
   }
@@ -739,7 +831,9 @@ async function handleMetricsApiRequestUnchecked(
     res.setHeader("deprecation", "true");
     sendJson(req, res, 501, {
       data: null,
-      errors: [{ message: "atBlock queries are not supported by the artifact-backed metrics API." }],
+      errors: [
+        { message: "atBlock queries are not supported by the artifact-backed metrics API." },
+      ],
     });
     return;
   }
@@ -747,7 +841,12 @@ async function handleMetricsApiRequestUnchecked(
   if (url.pathname === "/operations/health") {
     res.setHeader("deprecation", "true");
     res.setHeader("cache-control", READY_CACHE_CONTROL);
-    sendJson(req, res, 200, legacyResponse({ status: "ok", timestamp: new Date().toISOString(), version: "3.0.0" }));
+    sendJson(
+      req,
+      res,
+      200,
+      legacyResponse({ status: "ok", timestamp: new Date().toISOString(), version: "3.0.0" }),
+    );
     return;
   }
 
@@ -778,7 +877,13 @@ async function handleMetricsApiRequestUnchecked(
       if (error instanceof ArtifactNotFoundError) {
         return;
       }
-      sendError(req, res, 400, "invalid_legacy_request", error instanceof Error ? error.message : "Invalid legacy request.");
+      sendError(
+        req,
+        res,
+        400,
+        "invalid_legacy_request",
+        error instanceof Error ? error.message : "Invalid legacy request.",
+      );
     }
     return;
   }

--- a/apps/metrics-api/tests/server.test.ts
+++ b/apps/metrics-api/tests/server.test.ts
@@ -1,11 +1,10 @@
 import { createServer, request as httpRequest } from "node:http";
 import { type AddressInfo, connect } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
-
+import type { Manifest } from "../../../packages/metrics-artifacts/src";
 import { ArtifactNotFoundError } from "../src/artifact-store";
 import { metricsApiConfigFromEnv, metricsApiPortFromEnv } from "../src/config";
 import { handleMetricsApiRequest, type MetricsApiConfig } from "../src/server";
-import type { Manifest } from "../../../packages/metrics-artifacts/src";
 
 let closeServer: (() => Promise<void>) | undefined;
 
@@ -32,7 +31,9 @@ function artifactReader(objects: Record<string, unknown>): MetricsApiConfig["art
   };
 }
 
-function sparseArtifactReader(objects: Record<string, unknown>): MetricsApiConfig["artifactReader"] {
+function sparseArtifactReader(
+  objects: Record<string, unknown>,
+): MetricsApiConfig["artifactReader"] {
   return {
     async getJson<T>(key: string): Promise<T> {
       if (!(key in objects)) {
@@ -71,41 +72,41 @@ async function rawRequest(
     body: string;
     rawBody: Buffer;
   }>((resolve, reject) => {
-      const clientRequest = httpRequest(
-        {
-          host: "127.0.0.1",
-          port,
-          path,
-          method: init.method,
-          headers:
-            init.body === undefined
-              ? init.headers
-              : {
-                  ...init.headers,
-                  "content-length": Buffer.byteLength(init.body),
-                  "content-type": "application/json",
-                },
-        },
-        (response) => {
-          const chunks: Buffer[] = [];
-          response.on("data", (chunk: Buffer) => chunks.push(chunk));
-          response.on("end", () => {
-            const rawBody = Buffer.concat(chunks);
-            resolve({
-              status: response.statusCode ?? 0,
-              headers: response.headers,
-              body: rawBody.toString("utf8"),
-              rawBody,
-            });
+    const clientRequest = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: init.method,
+        headers:
+          init.body === undefined
+            ? init.headers
+            : {
+                ...init.headers,
+                "content-length": Buffer.byteLength(init.body),
+                "content-type": "application/json",
+              },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          const rawBody = Buffer.concat(chunks);
+          resolve({
+            status: response.statusCode ?? 0,
+            headers: response.headers,
+            body: rawBody.toString("utf8"),
+            rawBody,
           });
-        },
-      );
-      clientRequest.on("error", reject);
-      if (init.body !== undefined) {
-        clientRequest.write(init.body);
-      }
-      clientRequest.end();
-    });
+        });
+      },
+    );
+    clientRequest.on("error", reject);
+    if (init.body !== undefined) {
+      clientRequest.write(init.body);
+    }
+    clientRequest.end();
+  });
 }
 
 async function rawSocketRequest(
@@ -126,7 +127,9 @@ async function rawSocketRequest(
 
     socket.setEncoding("utf8");
     socket.on("connect", () => {
-      socket.write(`GET ${requestTarget} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`);
+      socket.write(
+        `GET ${requestTarget} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`,
+      );
     });
     socket.on("data", (chunk) => {
       response += chunk;
@@ -225,7 +228,10 @@ describe("metrics API HTTP behavior", () => {
     });
     expect(JSON.stringify(body)).not.toContain("leaked-secret");
     expect(JSON.stringify(body)).not.toContain("internal endpoint");
-    expect(errorSpy).toHaveBeenCalledWith("Metrics artifact manifest is unavailable.", backendError);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Metrics artifact manifest is unavailable.",
+      backendError,
+    );
   });
 
   test("returns the indexer deployment id in bounds when present", async () => {
@@ -279,9 +285,9 @@ describe("metrics API HTTP behavior", () => {
   test("sets cache headers for readiness, bounds, and range routes", async () => {
     expect((await request("/ready")).headers.get("cache-control")).toBe("no-store");
     expect((await request("/v2/bounds")).headers.get("cache-control")).toBe("no-store");
-    expect(
-      (await request("/v2/metrics/daily?start=2026-05-21")).headers.get("cache-control"),
-    ).toBe("public, max-age=3600");
+    expect((await request("/v2/metrics/daily?start=2026-05-21")).headers.get("cache-control")).toBe(
+      "public, max-age=3600",
+    );
   });
 
   test("rejects unsupported v2 query parameters that would otherwise cache-bust", async () => {
@@ -334,7 +340,9 @@ describe("metrics API HTTP behavior", () => {
       }),
     );
 
-    const canonical = await request(`/operations/paginated/metrics?wg_variables=${canonicalVariables}`);
+    const canonical = await request(
+      `/operations/paginated/metrics?wg_variables=${canonicalVariables}`,
+    );
     const withDateOffset = await request(
       `/operations/paginated/metrics?wg_variables=${encodeURIComponent(
         JSON.stringify({ startDate: "2026-05-21", endDate: "2026-05-21", dateOffset: 999 }),
@@ -343,7 +351,9 @@ describe("metrics API HTTP behavior", () => {
     const unsupportedTopLevel = await request(
       `/operations/paginated/metrics?cacheBust=one&wg_variables=${canonicalVariables}`,
     );
-    const unsupportedVariable = await request(`/operations/paginated/metrics?wg_variables=${unsupportedVariables}`);
+    const unsupportedVariable = await request(
+      `/operations/paginated/metrics?wg_variables=${unsupportedVariables}`,
+    );
 
     expect(withDateOffset.status).toBe(200);
     expect(await withDateOffset.json()).toEqual(await canonical.json());
@@ -452,7 +462,9 @@ describe("metrics API HTTP behavior", () => {
   });
 
   test("marks required chains as missing when no metric rows exist for a requested date", async () => {
-    const response = await request("/v2/metrics/daily?start=2026-05-21&end=2026-05-21&includeRecords=true");
+    const response = await request(
+      "/v2/metrics/daily?start=2026-05-21&end=2026-05-21&includeRecords=true",
+    );
     expect(response.status).toBe(200);
 
     const body = await response.json();
@@ -482,8 +494,16 @@ describe("metrics API HTTP behavior", () => {
         latestDate: "2026-05-21",
         artifacts: {
           "v2/metrics/daily/2026-05.json": { sha256: "0".repeat(64), byteLength: 2, rowCount: 1 },
-          "v2/treasury-assets/daily/2026-05.json": { sha256: "1".repeat(64), byteLength: 2, rowCount: 2 },
-          "v2/ohm-supply/daily/2026-05.json": { sha256: "2".repeat(64), byteLength: 2, rowCount: 2 },
+          "v2/treasury-assets/daily/2026-05.json": {
+            sha256: "1".repeat(64),
+            byteLength: 2,
+            rowCount: 2,
+          },
+          "v2/ohm-supply/daily/2026-05.json": {
+            sha256: "2".repeat(64),
+            byteLength: 2,
+            rowCount: 2,
+          },
         },
       },
       artifactReader: artifactReader({
@@ -569,14 +589,24 @@ describe("metrics API HTTP behavior", () => {
       data: [expect.objectContaining({ id: "asset-selected", block: 200 })],
     });
 
-    const ohmSupply = await request("/v2/ohm-supply/daily?start=2026-05-21&end=2026-05-21", undefined, config);
+    const ohmSupply = await request(
+      "/v2/ohm-supply/daily?start=2026-05-21&end=2026-05-21",
+      undefined,
+      config,
+    );
     expect(ohmSupply.status).toBe(200);
     expect(await ohmSupply.json()).toMatchObject({
       data: [expect.objectContaining({ id: "supply-selected", block: 200 })],
     });
 
-    const variables = encodeURIComponent(JSON.stringify({ startDate: "2026-05-21", endDate: "2026-05-21" }));
-    const legacyTokenRecords = await request(`/operations/paginated/tokenRecords?wg_variables=${variables}`, undefined, config);
+    const variables = encodeURIComponent(
+      JSON.stringify({ startDate: "2026-05-21", endDate: "2026-05-21" }),
+    );
+    const legacyTokenRecords = await request(
+      `/operations/paginated/tokenRecords?wg_variables=${variables}`,
+      undefined,
+      config,
+    );
     expect(legacyTokenRecords.status).toBe(200);
     expect(await legacyTokenRecords.json()).toEqual({
       data: [expect.objectContaining({ id: "asset-selected", block: 200 })],
@@ -701,7 +731,9 @@ describe("metrics API HTTP behavior", () => {
       crossChainDataComplete: true,
       includeRecords: true,
     });
-    const encoded = await request(`/operations/paginated/metrics?wg_variables=${encodeURIComponent(variables)}`);
+    const encoded = await request(
+      `/operations/paginated/metrics?wg_variables=${encodeURIComponent(variables)}`,
+    );
     expect(encoded.status).toBe(200);
     expect(await encoded.json()).toMatchObject({ data: expect.any(Array) });
 
@@ -716,7 +748,9 @@ describe("metrics API HTTP behavior", () => {
       endDate: "2026-06-01",
     });
 
-    const response = await request(`/operations/paginated/metrics?wg_variables=${encodeURIComponent(variables)}`);
+    const response = await request(
+      `/operations/paginated/metrics?wg_variables=${encodeURIComponent(variables)}`,
+    );
 
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({
@@ -745,9 +779,15 @@ describe("metrics API HTTP behavior", () => {
         ],
       }),
     };
-    const variables = encodeURIComponent(JSON.stringify({ startDate: "2026-05-20", endDate: "2026-05-21" }));
+    const variables = encodeURIComponent(
+      JSON.stringify({ startDate: "2026-05-20", endDate: "2026-05-21" }),
+    );
 
-    const response = await request(`/operations/paginated/metrics?wg_variables=${variables}`, undefined, config);
+    const response = await request(
+      `/operations/paginated/metrics?wg_variables=${variables}`,
+      undefined,
+      config,
+    );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
@@ -756,7 +796,9 @@ describe("metrics API HTTP behavior", () => {
   });
 
   test("rejects invalid legacy dates before clipping to manifest bounds", async () => {
-    const variables = encodeURIComponent(JSON.stringify({ startDate: "not-a-date", endDate: "2030-12-31" }));
+    const variables = encodeURIComponent(
+      JSON.stringify({ startDate: "not-a-date", endDate: "2030-12-31" }),
+    );
     const response = await request(`/operations/paginated/metrics?wg_variables=${variables}`);
 
     expect(response.status).toBe(400);
@@ -772,8 +814,16 @@ describe("metrics API HTTP behavior", () => {
         ...testManifest,
         artifacts: {
           "v2/metrics/daily/2026-05.json": { sha256: "0".repeat(64), byteLength: 2, rowCount: 1 },
-          "v2/treasury-assets/daily/2026-05.json": { sha256: "1".repeat(64), byteLength: 2, rowCount: 1 },
-          "v2/ohm-supply/daily/2026-05.json": { sha256: "2".repeat(64), byteLength: 2, rowCount: 1 },
+          "v2/treasury-assets/daily/2026-05.json": {
+            sha256: "1".repeat(64),
+            byteLength: 2,
+            rowCount: 1,
+          },
+          "v2/ohm-supply/daily/2026-05.json": {
+            sha256: "2".repeat(64),
+            byteLength: 2,
+            rowCount: 1,
+          },
         },
       },
       artifactReader: artifactReader({
@@ -818,9 +868,15 @@ describe("metrics API HTTP behavior", () => {
         ],
       }),
     };
-    const variables = encodeURIComponent(JSON.stringify({ startDate: "2026-05-21", endDate: "2026-05-21" }));
+    const variables = encodeURIComponent(
+      JSON.stringify({ startDate: "2026-05-21", endDate: "2026-05-21" }),
+    );
 
-    const metrics = await request(`/operations/paginated/metrics?wg_variables=${variables}`, undefined, config);
+    const metrics = await request(
+      `/operations/paginated/metrics?wg_variables=${variables}`,
+      undefined,
+      config,
+    );
     expect(metrics.status).toBe(200);
     const metricsBody = await metrics.json();
     expect(metricsBody).toEqual({
@@ -829,7 +885,11 @@ describe("metrics API HTTP behavior", () => {
     expect(metricsBody).not.toHaveProperty("meta");
     expect(metricsBody).not.toHaveProperty("error");
 
-    const tokenRecords = await request(`/operations/paginated/tokenRecords?wg_variables=${variables}`, undefined, config);
+    const tokenRecords = await request(
+      `/operations/paginated/tokenRecords?wg_variables=${variables}`,
+      undefined,
+      config,
+    );
     expect(tokenRecords.status).toBe(200);
     const tokenRecordsBody = await tokenRecords.json();
     expect(tokenRecordsBody).toEqual({

--- a/apps/metrics-publisher/src/artifact-store.ts
+++ b/apps/metrics-publisher/src/artifact-store.ts
@@ -72,7 +72,9 @@ export class MemoryArtifactStore implements ArtifactStore {
   }
 
   async listKeys(prefix: string): Promise<string[]> {
-    return Array.from(this.objects.keys()).filter((key) => key.startsWith(prefix)).sort();
+    return Array.from(this.objects.keys())
+      .filter((key) => key.startsWith(prefix))
+      .sort();
   }
 
   async deleteJson(key: string): Promise<void> {

--- a/apps/metrics-publisher/src/metrics-source.ts
+++ b/apps/metrics-publisher/src/metrics-source.ts
@@ -1,17 +1,17 @@
 import {
   ALL_CHAIN_IDS,
   CHAIN_NAMES,
-  emptyChainValues,
-  emptySupplyCategoryValues,
-  isCrossChainComplete,
+  type ChainIndexingProgress,
   type ChainName,
   type DailyMetric,
   type DateRange,
+  emptyChainValues,
+  emptySupplyCategoryValues,
+  type IndexingProgress,
+  isCrossChainComplete,
   type OhmSupply,
-  type ChainIndexingProgress,
   type SupplyCategoryValues,
   type TreasuryAsset,
-  type IndexingProgress,
 } from "../../../packages/metrics-artifacts/src";
 
 export type MetricsBounds = {
@@ -97,7 +97,9 @@ export class HasuraGraphqlMetricsSource implements MetricsSource {
     },
   ) {}
 
-  async fetchBounds(completeness: PublishBoundsCompleteness = "cross_chain"): Promise<MetricsBounds> {
+  async fetchBounds(
+    completeness: PublishBoundsCompleteness = "cross_chain",
+  ): Promise<MetricsBounds> {
     const completenessWhere =
       completeness === "all_chains"
         ? `{ chainsIndexed: { _contains: [${ALL_CHAIN_IDS.join(", ")}] } }`
@@ -122,7 +124,9 @@ export class HasuraGraphqlMetricsSource implements MetricsSource {
     const earliestDate = body.earliest?.[0]?.date;
     const latestDate = body.latest?.[0]?.date;
     if (earliestDate === undefined || latestDate === undefined) {
-      throw new MetricsNotDataReadyError("Hasura returned no complete GlobalMetricSnapshot bounds.");
+      throw new MetricsNotDataReadyError(
+        "Hasura returned no complete GlobalMetricSnapshot bounds.",
+      );
     }
     return { earliestDate, latestDate };
   }
@@ -147,19 +151,29 @@ export class HasuraGraphqlMetricsSource implements MetricsSource {
       }
     `);
     const chainRows = CHAIN_NAMES.flatMap((chainName) => {
-      const rows = body[chainProgressAlias(chainName)] as Array<RawChainIndexingProgress> | undefined;
+      const rows = body[chainProgressAlias(chainName)] as
+        | Array<RawChainIndexingProgress>
+        | undefined;
       return chainProgressFromRows(chainName, rows);
     });
     return indexingProgressFromChainRows(chainRows);
   }
 
   async fetchDailyMetrics(range: DateRange): Promise<DailyMetric[]> {
-    const rows = await this.paginate<RawDailyMetric>("GlobalMetricSnapshot", range, DAILY_METRIC_SELECTION);
+    const rows = await this.paginate<RawDailyMetric>(
+      "GlobalMetricSnapshot",
+      range,
+      DAILY_METRIC_SELECTION,
+    );
     return rows.map(normalizeDailyMetric);
   }
 
   async fetchTreasuryAssets(range: DateRange): Promise<TreasuryAsset[]> {
-    const rows = await this.paginate<RawTreasuryAsset>("TokenRecord", range, TREASURY_ASSET_SELECTION);
+    const rows = await this.paginate<RawTreasuryAsset>(
+      "TokenRecord",
+      range,
+      TREASURY_ASSET_SELECTION,
+    );
     return rows.map(normalizeTreasuryAsset);
   }
 
@@ -219,7 +233,9 @@ export class HasuraGraphqlMetricsSource implements MetricsSource {
     }
     const body = (await response.json()) as GraphqlResponse<T>;
     if (body.errors && body.errors.length > 0) {
-      throw new Error(`Hasura GraphQL error: ${body.errors.map((error) => error.message).join("; ")}`);
+      throw new Error(
+        `Hasura GraphQL error: ${body.errors.map((error) => error.message).join("; ")}`,
+      );
     }
     if (body.data === undefined) {
       throw new Error("Hasura GraphQL response did not include data.");
@@ -279,7 +295,14 @@ type RawDailyMetric = {
 
 type RawTreasuryAsset = Omit<
   TreasuryAsset,
-  "balance" | "block" | "blockchain" | "multiplier" | "rate" | "timestamp" | "value" | "valueExcludingOhm"
+  | "balance"
+  | "block"
+  | "blockchain"
+  | "multiplier"
+  | "rate"
+  | "timestamp"
+  | "value"
+  | "valueExcludingOhm"
 > & {
   balance: unknown;
   block: unknown;
@@ -291,7 +314,10 @@ type RawTreasuryAsset = Omit<
   valueExcludingOhm: unknown;
 };
 
-type RawOhmSupply = Omit<OhmSupply, "balance" | "block" | "blockchain" | "supplyBalance" | "timestamp"> & {
+type RawOhmSupply = Omit<
+  OhmSupply,
+  "balance" | "block" | "blockchain" | "supplyBalance" | "timestamp"
+> & {
   balance: unknown;
   block: unknown;
   blockchain: string;
@@ -440,7 +466,9 @@ function normalizeDailyMetric(row: RawDailyMetric): DailyMetric {
     treasuryLiquidBackingPerOhmBacked: toNumber(row.treasuryLiquidBackingPerOhmBacked),
     treasuryLiquidBackingPerGOhmBacked: toNumber(row.treasuryLiquidBackingPerGOhmBacked),
     _meta: {
-      chainsComplete: CHAIN_NAMES.filter((chain) => row.chainsIndexed.includes(chainIdForName(chain))),
+      chainsComplete: CHAIN_NAMES.filter((chain) =>
+        row.chainsIndexed.includes(chainIdForName(chain)),
+      ),
       chainsFailed: CHAIN_NAMES.filter((chain) => chainsMissing.includes(chainIdForName(chain))),
       timestamp: metricTimestamp(row.date, timestamps),
     },

--- a/apps/metrics-publisher/src/publisher.ts
+++ b/apps/metrics-publisher/src/publisher.ts
@@ -383,7 +383,9 @@ function resolvePublishRange(
   }
 
   const end = input.endDate ?? bounds.latestDate;
-  const start = input.startDate ?? maxDate(publicStartDate, firstDayOfPreviousMonth(end));
+  const firstUnpublishedMonth = firstDayOfMonth(addDays(existingManifest.latestDate, 1));
+  const refreshStart = minDate(firstDayOfPreviousMonth(end), firstUnpublishedMonth);
+  const start = input.startDate ?? maxDate(publicStartDate, refreshStart);
   return resolveDateRange({
     start,
     end,
@@ -583,6 +585,10 @@ function parseDeploymentId(value: string): string {
 
 function addDays(date: string, days: number): string {
   return new Date(Date.parse(`${date}T00:00:00.000Z`) + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+function firstDayOfMonth(date: string): string {
+  return `${date.slice(0, 7)}-01`;
 }
 
 function firstDayOfPreviousMonth(date: string): string {

--- a/apps/metrics-publisher/src/publisher.ts
+++ b/apps/metrics-publisher/src/publisher.ts
@@ -131,7 +131,6 @@ const SCHEMAS: Record<string, Record<string, unknown>> = {
 };
 
 export async function publishMetricsArtifacts(input: {
-  lookbackDays?: number;
   publicStartDate?: string;
   deploymentId: string;
   startDate?: string;
@@ -338,10 +337,8 @@ export async function publishMetricsArtifactsFromEnv(
   env: NodeJS.ProcessEnv = process.env,
   deps: { source?: MetricsSource; store?: ArtifactStore; now?: () => Date } = {},
 ): Promise<PublishResult> {
-  const lookbackDays = optionalEnv(env, "PUBLISHER_LOOKBACK_DAYS");
   const lockTtlMs = optionalEnv(env, "PUBLISHER_LOCK_TTL_MS");
   return publishMetricsArtifacts({
-    lookbackDays: lookbackDays === undefined ? undefined : Number(lookbackDays),
     publicStartDate: optionalEnv(env, "PUBLISHER_PUBLIC_START_DATE"),
     startDate: optionalEnv(env, "PUBLISHER_START_DATE"),
     endDate: optionalEnv(env, "PUBLISHER_END_DATE"),
@@ -370,7 +367,7 @@ function resolvePublisherDeploymentId(env: NodeJS.ProcessEnv): string {
 }
 
 function resolvePublishRange(
-  input: { lookbackDays?: number; startDate?: string; endDate?: string },
+  input: { startDate?: string; endDate?: string },
   bounds: MetricsBounds,
   existingManifest: Manifest | undefined,
   publicStartDate: string,
@@ -386,12 +383,6 @@ function resolvePublishRange(
   }
 
   const end = input.endDate ?? bounds.latestDate;
-  if (
-    input.lookbackDays !== undefined &&
-    (!Number.isInteger(input.lookbackDays) || input.lookbackDays < 1)
-  ) {
-    throw new Error("lookbackDays must be a positive integer.");
-  }
   const start = input.startDate ?? maxDate(publicStartDate, firstDayOfPreviousMonth(end));
   return resolveDateRange({
     start,

--- a/apps/metrics-publisher/src/publisher.ts
+++ b/apps/metrics-publisher/src/publisher.ts
@@ -1,39 +1,39 @@
 import { randomUUID } from "node:crypto";
 import {
-  monthKeysForRange,
-  resolveDateRange,
   type DateRange,
   type Manifest,
+  monthKeysForRange,
+  resolveDateRange,
 } from "../../../packages/metrics-artifacts/src";
 import {
+  type ArtifactEntry,
   ArtifactNotFoundError,
+  type ArtifactStore,
+  artifactEntry,
   MemoryArtifactStore,
   S3ArtifactStore,
-  artifactEntry,
-  type ArtifactEntry,
-  type ArtifactStore,
 } from "./artifact-store";
 import {
   EmptyMetricsSource,
   HasuraGraphqlMetricsSource,
-  MetricsNotDataReadyError,
   type LatestIndexingProgress,
   type MetricsBounds,
-  type PublishBoundsCompleteness,
+  MetricsNotDataReadyError,
   type MetricsSource,
+  type PublishBoundsCompleteness,
 } from "./metrics-source";
 
 export {
-  MemoryArtifactStore,
-  S3ArtifactStore,
   type ArtifactStore,
   EmptyMetricsSource,
   HasuraGraphqlMetricsSource,
-  MetricsNotDataReadyError,
   type LatestIndexingProgress,
+  MemoryArtifactStore,
   type MetricsBounds,
-  type PublishBoundsCompleteness,
+  MetricsNotDataReadyError,
   type MetricsSource,
+  type PublishBoundsCompleteness,
+  S3ArtifactStore,
 };
 
 export type PublisherIndexingProgress = {
@@ -154,7 +154,10 @@ export async function publishMetricsArtifacts(input: {
   }
   const existingManifest = input.manifest ?? (await getExistingManifest(store));
   const operation = existingManifest === undefined ? "initial_backfill" : "incremental_refresh";
-  const hasPublishedDeploymentArtifacts = deploymentHasPublishedArtifacts(existingManifest, deploymentId);
+  const hasPublishedDeploymentArtifacts = deploymentHasPublishedArtifacts(
+    existingManifest,
+    deploymentId,
+  );
   const lock = await acquirePublisherLock({
     store,
     operation,
@@ -178,7 +181,9 @@ export async function publishMetricsArtifacts(input: {
 
   try {
     let bounds: MetricsBounds;
-    const publishBoundsCompleteness = hasPublishedDeploymentArtifacts ? "cross_chain" : "all_chains";
+    const publishBoundsCompleteness = hasPublishedDeploymentArtifacts
+      ? "cross_chain"
+      : "all_chains";
     const latestIndexingProgress = await source.fetchLatestIndexingProgress();
     const indexingProgress: PublisherIndexingProgress = {
       chains: latestIndexingProgress.chains,
@@ -214,12 +219,30 @@ export async function publishMetricsArtifacts(input: {
         writtenKeys: [],
       };
     }
-    const range = resolvePublishRange(input, bounds, existingManifest, publicStartDate, hasPublishedDeploymentArtifacts);
+    const range = resolvePublishRange(
+      input,
+      bounds,
+      existingManifest,
+      publicStartDate,
+      hasPublishedDeploymentArtifacts,
+    );
     const [metrics, treasuryAssets, ohmSupply] = await Promise.all([
       source.fetchDailyMetrics(range),
       source.fetchTreasuryAssets(range),
       source.fetchOhmSupply(range),
     ]);
+    if (hasPublishedDeploymentArtifacts && hasMissingDailyMetrics(range, metrics)) {
+      return {
+        manifestPublishedLast: false,
+        deletedKeys: [],
+        deploymentId,
+        indexingProgress,
+        skipped: true,
+        skipReason: "not_data_ready",
+        runId: lock.runId,
+        writtenKeys: [],
+      };
+    }
 
     const writtenKeys: string[] = [];
     let deletedKeys: string[] = [];
@@ -244,12 +267,22 @@ export async function publishMetricsArtifacts(input: {
       const ohmSupplyRows = ohmSupply.filter((row) => row.date.startsWith(month));
 
       await writeArtifact(dataKey("metrics", month), metricRows, metricRows.length);
-      await writeArtifact(dataKey("treasury-assets", month), treasuryAssetRows, treasuryAssetRows.length);
+      await writeArtifact(
+        dataKey("treasury-assets", month),
+        treasuryAssetRows,
+        treasuryAssetRows.length,
+      );
       await writeArtifact(dataKey("ohm-supply", month), ohmSupplyRows, ohmSupplyRows.length);
     }
 
-    const earliestDate = maxDate(publicStartDate, minDate(existingManifest?.earliestDate ?? range.start, range.start));
-    const latestDate = minDate(maxDate(existingManifest?.latestDate ?? range.end, range.end), bounds.latestDate);
+    const earliestDate = maxDate(
+      publicStartDate,
+      minDate(existingManifest?.earliestDate ?? range.start, range.start),
+    );
+    const latestDate = minDate(
+      maxDate(existingManifest?.latestDate ?? range.end, range.end),
+      bounds.latestDate,
+    );
     const manifestArtifacts = pruneArtifactsOutsidePublishedBounds(
       pruneHistoricalDeploymentArtifacts(artifacts, deploymentId),
       earliestDate,
@@ -331,7 +364,9 @@ function resolvePublisherDeploymentId(env: NodeJS.ProcessEnv): string {
     return railwayGitCommitSha;
   }
 
-  throw new Error("Missing required environment variable INDEXER_DEPLOYMENT_ID or RAILWAY_GIT_COMMIT_SHA.");
+  throw new Error(
+    "Missing required environment variable INDEXER_DEPLOYMENT_ID or RAILWAY_GIT_COMMIT_SHA.",
+  );
 }
 
 function resolvePublishRange(
@@ -351,12 +386,13 @@ function resolvePublishRange(
   }
 
   const end = input.endDate ?? bounds.latestDate;
-  const lookbackDays = input.lookbackDays ?? 3;
-  if (!Number.isInteger(lookbackDays) || lookbackDays < 1) {
+  if (
+    input.lookbackDays !== undefined &&
+    (!Number.isInteger(input.lookbackDays) || input.lookbackDays < 1)
+  ) {
     throw new Error("lookbackDays must be a positive integer.");
   }
-  const catchupBaseDate = minDate(existingManifest.latestDate, bounds.latestDate);
-  const start = input.startDate ?? maxDate(publicStartDate, addDays(catchupBaseDate, -(lookbackDays - 1)));
+  const start = input.startDate ?? maxDate(publicStartDate, firstDayOfPreviousMonth(end));
   return resolveDateRange({
     start,
     end,
@@ -376,7 +412,10 @@ async function getExistingManifest(store: ArtifactStore): Promise<Manifest | und
   }
 }
 
-async function cleanupHistoricalDeploymentArtifacts(store: ArtifactStore, currentDeploymentId: string): Promise<string[]> {
+async function cleanupHistoricalDeploymentArtifacts(
+  store: ArtifactStore,
+  currentDeploymentId: string,
+): Promise<string[]> {
   const currentPrefix = `v2/deployments/${currentDeploymentId}/`;
   const keys = await store.listKeys("v2/deployments/");
   const staleKeys = keys.filter((key) => !key.startsWith(currentPrefix));
@@ -392,11 +431,16 @@ function pruneHistoricalDeploymentArtifacts(
 ): Record<string, ArtifactEntry> {
   const currentPrefix = `v2/deployments/${currentDeploymentId}/`;
   return Object.fromEntries(
-    Object.entries(artifacts).filter(([key]) => !key.startsWith("v2/deployments/") || key.startsWith(currentPrefix)),
+    Object.entries(artifacts).filter(
+      ([key]) => !key.startsWith("v2/deployments/") || key.startsWith(currentPrefix),
+    ),
   );
 }
 
-function deploymentHasPublishedArtifacts(manifest: Manifest | undefined, deploymentId: string): boolean {
+function deploymentHasPublishedArtifacts(
+  manifest: Manifest | undefined,
+  deploymentId: string,
+): boolean {
   if (manifest === undefined) {
     return false;
   }
@@ -413,7 +457,9 @@ function pruneArtifactsOutsidePublishedBounds(
   earliestDate: string,
   latestDate: string,
 ): Record<string, ArtifactEntry> {
-  const publishedMonths = new Set(monthKeysForRange({ start: earliestDate, end: latestDate, days: 1 }));
+  const publishedMonths = new Set(
+    monthKeysForRange({ start: earliestDate, end: latestDate, days: 1 }),
+  );
   return Object.fromEntries(
     Object.entries(artifacts).filter(([key]) => {
       const month = dataArtifactMonth(key);
@@ -424,9 +470,24 @@ function pruneArtifactsOutsidePublishedBounds(
 
 function dataArtifactMonth(key: string): string | undefined {
   return (
-    key.match(/^v2\/deployments\/[^/]+\/(?:metrics|treasury-assets|ohm-supply)\/daily\/(\d{4}-\d{2})\.json$/)?.[1] ??
+    key.match(
+      /^v2\/deployments\/[^/]+\/(?:metrics|treasury-assets|ohm-supply)\/daily\/(\d{4}-\d{2})\.json$/,
+    )?.[1] ??
     key.match(/^v2\/(?:metrics|treasury-assets|ohm-supply)\/daily\/(\d{4}-\d{2})\.json$/)?.[1]
   );
+}
+
+function hasMissingDailyMetrics(range: DateRange, metrics: Array<{ date: string }>): boolean {
+  const dates = new Set(metrics.map((metric) => metric.date));
+  let cursor = Date.parse(`${range.start}T00:00:00.000Z`);
+  const end = Date.parse(`${range.end}T00:00:00.000Z`);
+  while (cursor <= end) {
+    if (!dates.has(new Date(cursor).toISOString().slice(0, 10))) {
+      return true;
+    }
+    cursor += DAY_MS;
+  }
+  return false;
 }
 
 function isFreshForDeploymentHandover(latestDate: string, now: Date): boolean {
@@ -522,13 +583,22 @@ function parseDeploymentId(value: string): string {
     throw new Error("INDEXER_DEPLOYMENT_ID is required.");
   }
   if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
-    throw new Error("INDEXER_DEPLOYMENT_ID may contain only letters, numbers, dots, underscores, and dashes.");
+    throw new Error(
+      "INDEXER_DEPLOYMENT_ID may contain only letters, numbers, dots, underscores, and dashes.",
+    );
   }
   return trimmed;
 }
 
 function addDays(date: string, days: number): string {
   return new Date(Date.parse(`${date}T00:00:00.000Z`) + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+function firstDayOfPreviousMonth(date: string): string {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth() - 1, 1))
+    .toISOString()
+    .slice(0, 10);
 }
 
 function maxDate(a: string, b: string): string {

--- a/apps/metrics-publisher/tests/publisher.test.ts
+++ b/apps/metrics-publisher/tests/publisher.test.ts
@@ -204,6 +204,22 @@ function completeDailyMetrics(range: { start: string; end: string }): DailyMetri
   return dateKeys(range).map((date) => ({ ...metric, date }));
 }
 
+function completeTreasuryAssets(range: { start: string; end: string }): TreasuryAsset[] {
+  return dateKeys(range).map((date) => ({
+    ...treasuryAsset,
+    id: `asset-${date}`,
+    date,
+  }));
+}
+
+function completeOhmSupply(range: { start: string; end: string }): OhmSupply[] {
+  return dateKeys(range).map((date) => ({
+    ...ohmSupply,
+    id: `supply-${date}`,
+    date,
+  }));
+}
+
 function dateKeys(range: { start: string; end: string }): string[] {
   const keys: string[] = [];
   let cursor = Date.parse(`${range.start}T00:00:00.000Z`);
@@ -213,6 +229,14 @@ function dateKeys(range: { start: string; end: string }): string[] {
     cursor += 24 * 60 * 60 * 1000;
   }
   return keys;
+}
+
+function expectArtifactDates<T extends { date: string }>(
+  store: MemoryArtifactStore,
+  key: string,
+  expectedDates: string[],
+): void {
+  expect(store.json<T[]>(key).map((row) => row.date)).toEqual(expectedDates);
 }
 
 describe("metrics publisher", () => {
@@ -285,12 +309,16 @@ describe("metrics publisher", () => {
   test("publishes from the existing manifest with a lookback overlap", async () => {
     const store = new MemoryArtifactStore();
     await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+    const mayDates = dateKeys({ start: "2026-05-01", end: "2026-05-31" });
+    const juneDates = ["2026-06-01"];
 
     const result = await publishMetricsArtifacts({
       deploymentId: "current-indexer",
       lookbackDays: 2,
       source: source({
         fetchDailyMetrics: async (range) => completeDailyMetrics(range),
+        fetchTreasuryAssets: async (range) => completeTreasuryAssets(range),
+        fetchOhmSupply: async (range) => completeOhmSupply(range),
       }),
       store,
       now: () => new Date(generatedAt),
@@ -303,11 +331,43 @@ describe("metrics publisher", () => {
     expect(result.writtenKeys).toContain(
       "v2/deployments/current-indexer/metrics/daily/2026-06.json",
     );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+      mayDates,
+    );
+    expectArtifactDates<TreasuryAsset>(
+      store,
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-05.json",
+      mayDates,
+    );
+    expectArtifactDates<OhmSupply>(
+      store,
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-05.json",
+      mayDates,
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+      juneDates,
+    );
+    expectArtifactDates<TreasuryAsset>(
+      store,
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-06.json",
+      juneDates,
+    );
+    expectArtifactDates<OhmSupply>(
+      store,
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-06.json",
+      juneDates,
+    );
   });
 
   test("incremental publish regenerates previous and current month at a month border", async () => {
     const store = new MemoryArtifactStore();
     await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+    const juneDates = dateKeys({ start: "2026-06-01", end: "2026-06-30" });
+    const julyDates = ["2026-07-01"];
 
     const observedRanges: Array<{ start: string; end: string; days: number }> = [];
     const result = await publishMetricsArtifacts({
@@ -318,6 +378,8 @@ describe("metrics publisher", () => {
           observedRanges.push(range);
           return completeDailyMetrics(range);
         },
+        fetchTreasuryAssets: async (range) => completeTreasuryAssets(range),
+        fetchOhmSupply: async (range) => completeOhmSupply(range),
       }),
       store,
       now: () => new Date("2026-07-01T09:15:00.000Z"),
@@ -330,6 +392,36 @@ describe("metrics publisher", () => {
     );
     expect(result.writtenKeys).toContain(
       "v2/deployments/current-indexer/metrics/daily/2026-07.json",
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+      juneDates,
+    );
+    expectArtifactDates<TreasuryAsset>(
+      store,
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-06.json",
+      juneDates,
+    );
+    expectArtifactDates<OhmSupply>(
+      store,
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-06.json",
+      juneDates,
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-07.json",
+      julyDates,
+    );
+    expectArtifactDates<TreasuryAsset>(
+      store,
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-07.json",
+      julyDates,
+    );
+    expectArtifactDates<OhmSupply>(
+      store,
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-07.json",
+      julyDates,
     );
   });
 

--- a/apps/metrics-publisher/tests/publisher.test.ts
+++ b/apps/metrics-publisher/tests/publisher.test.ts
@@ -364,7 +364,17 @@ describe("metrics publisher", () => {
 
   test("incremental publish regenerates previous and current month at a month border", async () => {
     const store = new MemoryArtifactStore();
-    await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+    await store.putJson("v2/manifest.json", {
+      ...existingCurrentDeploymentManifest,
+      latestDate: "2026-06-30",
+      artifacts: {
+        "v2/deployments/current-indexer/metrics/daily/2026-06.json": {
+          sha256: "0".repeat(64),
+          byteLength: 2,
+          rowCount: 30,
+        },
+      },
+    });
     const juneDates = dateKeys({ start: "2026-06-01", end: "2026-06-30" });
     const julyDates = ["2026-07-01"];
 
@@ -421,6 +431,72 @@ describe("metrics publisher", () => {
       store,
       "v2/deployments/current-indexer/ohm-supply/daily/2026-07.json",
       julyDates,
+    );
+  });
+
+  test("incremental publish backfills unpublished months before the normal refresh window", async () => {
+    const store = new MemoryArtifactStore();
+    await store.putJson("v2/manifest.json", {
+      ...existingCurrentDeploymentManifest,
+      latestDate: "2026-03-31",
+      artifacts: {
+        "v2/deployments/current-indexer/metrics/daily/2026-03.json": {
+          sha256: "0".repeat(64),
+          byteLength: 2,
+          rowCount: 31,
+        },
+      },
+    });
+    const aprilDates = dateKeys({ start: "2026-04-01", end: "2026-04-30" });
+    const mayDates = dateKeys({ start: "2026-05-01", end: "2026-05-31" });
+    const juneDates = dateKeys({ start: "2026-06-01", end: "2026-06-17" });
+
+    const result = await publishMetricsArtifacts({
+      deploymentId: "current-indexer",
+      source: source({
+        fetchBounds: async () => ({ earliestDate: "2026-03-01", latestDate: "2026-06-17" }),
+        fetchDailyMetrics: async (range) => completeDailyMetrics(range),
+        fetchTreasuryAssets: async (range) => completeTreasuryAssets(range),
+        fetchOhmSupply: async (range) => completeOhmSupply(range),
+      }),
+      store,
+      now: () => new Date("2026-06-17T09:15:00.000Z"),
+    });
+
+    expect(result.range).toEqual({ start: "2026-04-01", end: "2026-06-17", days: 78 });
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-04.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-04.json",
+      aprilDates,
+    );
+    expectArtifactDates<TreasuryAsset>(
+      store,
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-04.json",
+      aprilDates,
+    );
+    expectArtifactDates<OhmSupply>(
+      store,
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-04.json",
+      aprilDates,
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+      mayDates,
+    );
+    expectArtifactDates<DailyMetric>(
+      store,
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+      juneDates,
     );
   });
 

--- a/apps/metrics-publisher/tests/publisher.test.ts
+++ b/apps/metrics-publisher/tests/publisher.test.ts
@@ -306,7 +306,7 @@ describe("metrics publisher", () => {
     );
   });
 
-  test("publishes from the existing manifest with a lookback overlap", async () => {
+  test("publishes from the existing manifest by regenerating previous and current month", async () => {
     const store = new MemoryArtifactStore();
     await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
     const mayDates = dateKeys({ start: "2026-05-01", end: "2026-05-31" });
@@ -314,7 +314,6 @@ describe("metrics publisher", () => {
 
     const result = await publishMetricsArtifacts({
       deploymentId: "current-indexer",
-      lookbackDays: 2,
       source: source({
         fetchDailyMetrics: async (range) => completeDailyMetrics(range),
         fetchTreasuryAssets: async (range) => completeTreasuryAssets(range),
@@ -461,7 +460,6 @@ describe("metrics publisher", () => {
 
     const result = await publishMetricsArtifacts({
       deploymentId: "current-indexer",
-      lookbackDays: 2,
       source: source({
         fetchBounds: async (completeness) => {
           observedCompleteness.push(completeness ?? "cross_chain");
@@ -555,7 +553,6 @@ describe("metrics publisher", () => {
 
     const result = await publishMetricsArtifacts({
       deploymentId: "current-indexer",
-      lookbackDays: 2,
       source: source({
         fetchBounds: async (completeness) => {
           observedCompleteness.push(completeness ?? "cross_chain");
@@ -710,7 +707,6 @@ describe("metrics publisher", () => {
 
     const result = await publishMetricsArtifacts({
       deploymentId: "new-indexer",
-      lookbackDays: 2,
       source: source(),
       store,
       now: () => new Date(generatedAt),
@@ -868,7 +864,6 @@ describe("metrics publisher", () => {
         HASURA_GRAPHQL_ADMIN_SECRET: "secret",
         ...validPublisherArtifactEnv,
         INDEXER_DEPLOYMENT_ID: "current-indexer",
-        PUBLISHER_LOOKBACK_DAYS: "2",
         PUBLISHER_PUBLIC_START_DATE: "2022-05-01",
         PUBLISHER_START_DATE: "",
         PUBLISHER_END_DATE: "   ",

--- a/apps/metrics-publisher/tests/publisher.test.ts
+++ b/apps/metrics-publisher/tests/publisher.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, test } from "vitest";
-
+import type {
+  DailyMetric,
+  Manifest,
+  OhmSupply,
+  TreasuryAsset,
+} from "../../../packages/metrics-artifacts/src";
 import {
+  type ArtifactStore,
+  createArtifactStoreFromEnv,
+  createMetricsSourceFromEnv,
   HasuraGraphqlMetricsSource,
   MemoryArtifactStore,
   MetricsNotDataReadyError,
-  S3ArtifactStore,
-  createArtifactStoreFromEnv,
-  createMetricsSourceFromEnv,
-  publishMetricsArtifacts,
-  publishMetricsArtifactsFromEnv,
-  type ArtifactStore,
   type MetricsSource,
   type PublishBoundsCompleteness,
+  publishMetricsArtifacts,
+  publishMetricsArtifactsFromEnv,
+  S3ArtifactStore,
 } from "../src/publisher";
-import type { DailyMetric, Manifest, OhmSupply, TreasuryAsset } from "../../../packages/metrics-artifacts/src";
 
 const generatedAt = "2026-06-01T08:15:00.000Z";
 
@@ -34,14 +38,42 @@ const metric: DailyMetric = {
   ohmIndex: 1,
   ohmApy: 2,
   ohmTotalSupply: 3,
-  ohmTotalSupplyComponents: { Arbitrum: 0, Ethereum: 3, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  ohmTotalSupplyComponents: {
+    Arbitrum: 0,
+    Ethereum: 3,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   ohmCirculatingSupply: 4,
-  ohmCirculatingSupplyComponents: { Arbitrum: 0, Ethereum: 4, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  ohmCirculatingSupplyComponents: {
+    Arbitrum: 0,
+    Ethereum: 4,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   ohmFloatingSupply: 5,
-  ohmFloatingSupplyComponents: { Arbitrum: 0, Ethereum: 5, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  ohmFloatingSupplyComponents: {
+    Arbitrum: 0,
+    Ethereum: 5,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   ohmBackedSupply: 6,
   gOhmBackedSupply: 7,
-  ohmBackedSupplyComponents: { Arbitrum: 0, Ethereum: 6, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  ohmBackedSupplyComponents: {
+    Arbitrum: 0,
+    Ethereum: 6,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   ohmSupplyCategories: {
     BondsDeposits: 0,
     BondsPreminted: 0,
@@ -60,9 +92,23 @@ const metric: DailyMetric = {
   sOhmCirculatingSupply: 11,
   sOhmTotalValueLocked: 12,
   treasuryMarketValue: 13,
-  treasuryMarketValueComponents: { Arbitrum: 0, Ethereum: 13, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  treasuryMarketValueComponents: {
+    Arbitrum: 0,
+    Ethereum: 13,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   treasuryLiquidBacking: 14,
-  treasuryLiquidBackingComponents: { Arbitrum: 0, Ethereum: 14, Fantom: 0, Polygon: 0, Base: 0, Berachain: 0 },
+  treasuryLiquidBackingComponents: {
+    Arbitrum: 0,
+    Ethereum: 14,
+    Fantom: 0,
+    Polygon: 0,
+    Base: 0,
+    Berachain: 0,
+  },
   treasuryLiquidBackingPerOhmFloating: 15,
   treasuryLiquidBackingPerOhmBacked: 16,
   treasuryLiquidBackingPerGOhmBacked: 17,
@@ -154,6 +200,21 @@ function source(overrides: Partial<MetricsSource> = {}): MetricsSource {
   };
 }
 
+function completeDailyMetrics(range: { start: string; end: string }): DailyMetric[] {
+  return dateKeys(range).map((date) => ({ ...metric, date }));
+}
+
+function dateKeys(range: { start: string; end: string }): string[] {
+  const keys: string[] = [];
+  let cursor = Date.parse(`${range.start}T00:00:00.000Z`);
+  const end = Date.parse(`${range.end}T00:00:00.000Z`);
+  while (cursor <= end) {
+    keys.push(new Date(cursor).toISOString().slice(0, 10));
+    cursor += 24 * 60 * 60 * 1000;
+  }
+  return keys;
+}
+
 describe("metrics publisher", () => {
   test("publishes manifest last after writing metric, treasury asset, and OHM supply shards", async () => {
     const result = await publishMetricsArtifacts({
@@ -165,9 +226,15 @@ describe("metrics publisher", () => {
     });
 
     expect(result.manifestPublishedLast).toBe(true);
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-05.json");
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/treasury-assets/daily/2026-05.json");
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/ohm-supply/daily/2026-05.json");
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-05.json",
+    );
     expect(result.writtenKeys.at(-1)).toBe("v2/manifest.json");
   });
 
@@ -207,8 +274,12 @@ describe("metrics publisher", () => {
       byteLength: expect.any(Number),
       sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
-    expect(artifacts["v2/deployments/current-indexer/treasury-assets/daily/2026-05.json"].rowCount).toBe(1);
-    expect(artifacts["v2/deployments/current-indexer/ohm-supply/daily/2026-05.json"].rowCount).toBe(1);
+    expect(
+      artifacts["v2/deployments/current-indexer/treasury-assets/daily/2026-05.json"].rowCount,
+    ).toBe(1);
+    expect(artifacts["v2/deployments/current-indexer/ohm-supply/daily/2026-05.json"].rowCount).toBe(
+      1,
+    );
   });
 
   test("publishes from the existing manifest with a lookback overlap", async () => {
@@ -218,14 +289,76 @@ describe("metrics publisher", () => {
     const result = await publishMetricsArtifacts({
       deploymentId: "current-indexer",
       lookbackDays: 2,
-      source: source(),
+      source: source({
+        fetchDailyMetrics: async (range) => completeDailyMetrics(range),
+      }),
       store,
       now: () => new Date(generatedAt),
     });
 
-    expect(result.range).toEqual({ start: "2026-05-29", end: "2026-06-01", days: 4 });
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-05.json");
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-06.json");
+    expect(result.range).toEqual({ start: "2026-05-01", end: "2026-06-01", days: 32 });
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+    );
+  });
+
+  test("incremental publish regenerates previous and current month at a month border", async () => {
+    const store = new MemoryArtifactStore();
+    await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+
+    const observedRanges: Array<{ start: string; end: string; days: number }> = [];
+    const result = await publishMetricsArtifacts({
+      deploymentId: "current-indexer",
+      source: source({
+        fetchBounds: async () => ({ earliestDate: "2026-04-30", latestDate: "2026-07-01" }),
+        fetchDailyMetrics: async (range) => {
+          observedRanges.push(range);
+          return completeDailyMetrics(range);
+        },
+      }),
+      store,
+      now: () => new Date("2026-07-01T09:15:00.000Z"),
+    });
+
+    expect(result.range).toEqual({ start: "2026-06-01", end: "2026-07-01", days: 31 });
+    expect(observedRanges).toEqual([{ start: "2026-06-01", end: "2026-07-01", days: 31 }]);
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-07.json",
+    );
+  });
+
+  test("incremental publish skips instead of overwriting a monthly shard with sparse rows", async () => {
+    const store = new MemoryArtifactStore();
+    await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+
+    const result = await publishMetricsArtifacts({
+      deploymentId: "current-indexer",
+      source: source({
+        fetchBounds: async () => ({ earliestDate: "2026-04-30", latestDate: "2026-06-17" }),
+        fetchDailyMetrics: async () => [
+          { ...metric, date: "2026-06-15" },
+          { ...metric, date: "2026-06-16" },
+          { ...metric, date: "2026-06-17" },
+        ],
+      }),
+      store,
+      now: () => new Date("2026-06-17T09:15:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      skipped: true,
+      skipReason: "not_data_ready",
+      manifestPublishedLast: false,
+      writtenKeys: [],
+      deletedKeys: [],
+    });
+    expect(store.json<Manifest>("v2/manifest.json")).toEqual(existingCurrentDeploymentManifest);
   });
 
   test("first publish for a deployment only publishes up to the latest all-chain indexed snapshot", async () => {
@@ -273,8 +406,12 @@ describe("metrics publisher", () => {
       { start: "2022-05-01", end: "2026-05-31", days: 1492 },
       { start: "2022-05-01", end: "2026-05-31", days: 1492 },
     ]);
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-05.json");
-    expect(result.writtenKeys).not.toContain("v2/deployments/current-indexer/metrics/daily/2026-06.json");
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).not.toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+    );
     expect(store.json<Manifest>("v2/manifest.json")).toMatchObject({
       latestDate: "2026-05-31",
       indexerDeploymentId: "current-indexer",
@@ -332,20 +469,23 @@ describe("metrics publisher", () => {
           observedCompleteness.push(completeness ?? "cross_chain");
           return { earliestDate: "2026-04-30", latestDate: "2026-06-01" };
         },
+        fetchDailyMetrics: async (range) => completeDailyMetrics(range),
       }),
       store,
       now: () => new Date(generatedAt),
     });
 
     expect(observedCompleteness).toEqual(["cross_chain"]);
-    expect(result.range).toEqual({ start: "2026-05-29", end: "2026-06-01", days: 4 });
+    expect(result.range).toEqual({ start: "2026-05-01", end: "2026-06-01", days: 32 });
     expect(result.indexingProgress).toMatchObject({
       chains: {
         Arbitrum: { block: 100, date: "2026-06-01", timestamp: 1780272000 },
         Ethereum: { block: 200, date: "2026-06-01", timestamp: 1780272000 },
       },
     });
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-06.json");
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-06.json",
+    );
   });
 
   test("skips without replacing the manifest when no complete Hasura bounds exist", async () => {
@@ -363,7 +503,9 @@ describe("metrics publisher", () => {
         }),
         fetchBounds: async (completeness) => {
           observedCompleteness.push(completeness ?? "cross_chain");
-          throw new MetricsNotDataReadyError("Hasura returned no complete GlobalMetricSnapshot bounds.");
+          throw new MetricsNotDataReadyError(
+            "Hasura returned no complete GlobalMetricSnapshot bounds.",
+          );
         },
         fetchDailyMetrics: async () => {
           throw new Error("should not fetch daily metrics while data is not ready");
@@ -421,9 +563,15 @@ describe("metrics publisher", () => {
       now: () => new Date(generatedAt),
     });
 
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/metrics/daily/2026-05.json");
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/treasury-assets/daily/2026-05.json");
-    expect(result.writtenKeys).toContain("v2/deployments/current-indexer/ohm-supply/daily/2026-05.json");
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/metrics/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/treasury-assets/daily/2026-05.json",
+    );
+    expect(result.writtenKeys).toContain(
+      "v2/deployments/current-indexer/ohm-supply/daily/2026-05.json",
+    );
     expect(result.deletedKeys).toEqual(["v2/deployments/old-indexer/metrics/daily/2026-05.json"]);
 
     const manifest = store.json<Manifest>("v2/manifest.json");
@@ -433,10 +581,12 @@ describe("metrics publisher", () => {
       rowCount: 1,
     });
     expect(artifacts["v2/deployments/old-indexer/metrics/daily/2026-05.json"]).toBeUndefined();
-    await expect(store.getJson("v2/deployments/old-indexer/metrics/daily/2026-05.json")).rejects.toThrow(
-      "Artifact not found",
-    );
-    await expect(store.getJson("v2/deployments/current-indexer/metrics/daily/2026-04.json")).resolves.toEqual([]);
+    await expect(
+      store.getJson("v2/deployments/old-indexer/metrics/daily/2026-05.json"),
+    ).rejects.toThrow("Artifact not found");
+    await expect(
+      store.getJson("v2/deployments/current-indexer/metrics/daily/2026-04.json"),
+    ).resolves.toEqual([]);
   });
 
   test("handles a changed indexer deployment id by replacing deployment-scoped artifacts", async () => {
@@ -487,16 +637,18 @@ describe("metrics publisher", () => {
     const manifest = store.json<Manifest>("v2/manifest.json");
     const artifacts = requireArtifacts(manifest);
     expect(manifest).toMatchObject({ indexerDeploymentId: "new-indexer" });
-    expect(Object.keys(artifacts).some((key) => key.startsWith("v2/deployments/old-indexer/"))).toBe(false);
+    expect(
+      Object.keys(artifacts).some((key) => key.startsWith("v2/deployments/old-indexer/")),
+    ).toBe(false);
     expect(artifacts["v2/deployments/new-indexer/metrics/daily/2026-05.json"]).toMatchObject({
       rowCount: 1,
     });
     expect(artifacts["v2/deployments/new-indexer/metrics/daily/2026-06.json"]).toMatchObject({
       rowCount: 1,
     });
-    await expect(store.getJson("v2/deployments/old-indexer/metrics/daily/2026-05.json")).rejects.toThrow(
-      "Artifact not found",
-    );
+    await expect(
+      store.getJson("v2/deployments/old-indexer/metrics/daily/2026-05.json"),
+    ).rejects.toThrow("Artifact not found");
   });
 
   test("rejects unsafe indexer deployment ids", async () => {
@@ -576,7 +728,9 @@ describe("metrics publisher", () => {
           now: () => new Date(generatedAt),
         },
       ),
-    ).rejects.toThrow("Missing required environment variable INDEXER_DEPLOYMENT_ID or RAILWAY_GIT_COMMIT_SHA");
+    ).rejects.toThrow(
+      "Missing required environment variable INDEXER_DEPLOYMENT_ID or RAILWAY_GIT_COMMIT_SHA",
+    );
   });
 
   test("requires Hasura env variables before constructing the publisher source", () => {
@@ -628,13 +782,15 @@ describe("metrics publisher", () => {
         PUBLISHER_END_DATE: "   ",
       },
       {
-        source: source(),
+        source: source({
+          fetchDailyMetrics: async (range) => completeDailyMetrics(range),
+        }),
         store,
         now: () => new Date(generatedAt),
       },
     );
 
-    expect(result.range).toEqual({ start: "2026-05-29", end: "2026-06-01", days: 4 });
+    expect(result.range).toEqual({ start: "2026-05-01", end: "2026-06-01", days: 32 });
   });
 
   test("skips cleanly when a fresh publisher lock already exists", async () => {
@@ -731,7 +887,9 @@ describe("metrics publisher", () => {
     });
 
     await store.putJson("v2/manifest.json", { ok: true });
-    await expect(store.putJsonIfAbsent("v2/publisher.lock", { runId: "run-1" })).resolves.toBe(true);
+    await expect(store.putJsonIfAbsent("v2/publisher.lock", { runId: "run-1" })).resolves.toBe(
+      true,
+    );
 
     expect(commands).toHaveLength(2);
     expect(commands[0].input).toMatchObject({
@@ -802,7 +960,11 @@ describe("metrics publisher", () => {
         }),
     });
 
-    const [metric] = await source.fetchDailyMetrics({ start: "2026-05-21", end: "2026-05-21", days: 1 });
+    const [metric] = await source.fetchDailyMetrics({
+      start: "2026-05-21",
+      end: "2026-05-21",
+      days: 1,
+    });
 
     expect(metric.chainsIndexed).toEqual([1, 42161]);
     expect(metric.chainsMissing).toEqual([250, 137, 8453, 80094]);
@@ -877,9 +1039,9 @@ describe("metrics publisher", () => {
       },
     });
 
-    await expect(source.fetchTreasuryAssets({ start: "2026-05-01", end: "2026-05-31", days: 31 })).resolves.toEqual(
-      [],
-    );
+    await expect(
+      source.fetchTreasuryAssets({ start: "2026-05-01", end: "2026-05-31", days: 31 }),
+    ).resolves.toEqual([]);
     expect(requestBody?.query).toContain("order_by: { date: asc, id: asc }");
   });
 

--- a/docs/local-compose.md
+++ b/docs/local-compose.md
@@ -93,9 +93,9 @@ historical backfill from `2022-05-01` through Hasura's latest date where every
 supported chain id is indexed. That latest all-chain date must also be within
 one day of the current UTC date, otherwise the publisher exits successfully with
 `skipReason: "not_data_ready"` and leaves any existing manifest untouched. After
-that, the same command performs incremental catch-up from the existing manifest
-latest date with the configured lookback overlap; incremental runs only require
-the Arbitrum/Ethereum `crossChainComplete` gate.
+that, the same command performs incremental catch-up by regenerating the
+previous and current month based on Hasura's latest complete date; incremental
+runs only require the Arbitrum/Ethereum `crossChainComplete` gate.
 
 To clear only the local artifact bucket while keeping the rest of the compose
 stack running:
@@ -135,12 +135,11 @@ Most variables have local defaults. Override these when needed:
   indexer, default `http://hasura:8080/v1/metadata`.
 - `INDEXER_PORT`: internal Envio indexer HTTP port, default `9898`. The indexer
   startup wrapper derives `ENVIO_INDEXER_PORT` from this value.
-- `PUBLISHER_PUBLIC_START_DATE`, `PUBLISHER_LOOKBACK_DAYS`,
-  `PUBLISHER_LOCK_TTL_MS`, `PUBLISHER_START_DATE`, and
-  `PUBLISHER_END_DATE`: publisher range and overlap controls. If no manifest
-  exists, publishing starts at `2022-05-01`; otherwise it uses the manifest
-  latest date plus the lookback overlap. A fresh `v2/publisher.lock` makes
-  overlapping publisher runs exit successfully without writing artifacts.
+- `PUBLISHER_PUBLIC_START_DATE`, `PUBLISHER_LOCK_TTL_MS`,
+  `PUBLISHER_START_DATE`, and `PUBLISHER_END_DATE`: publisher range controls. If
+  no manifest exists, publishing starts at `2022-05-01`; otherwise it regenerates
+  the previous and current month. A fresh `v2/publisher.lock` makes overlapping
+  publisher runs exit successfully without writing artifacts.
 - `INDEXER_DEPLOYMENT_ID`: deployment identifier stamped into the internal
   manifest. `pnpm run compose:publish` sets it to the latest local git commit
   hash. If running Docker Compose directly, set it manually or provide

--- a/docs/local-compose.md
+++ b/docs/local-compose.md
@@ -93,9 +93,10 @@ historical backfill from `2022-05-01` through Hasura's latest date where every
 supported chain id is indexed. That latest all-chain date must also be within
 one day of the current UTC date, otherwise the publisher exits successfully with
 `skipReason: "not_data_ready"` and leaves any existing manifest untouched. After
-that, the same command performs incremental catch-up by regenerating the
-previous and current month based on Hasura's latest complete date; incremental
-runs only require the Arbitrum/Ethereum `crossChainComplete` gate.
+that, the same command performs incremental catch-up by backfilling unpublished
+months and regenerating at least the previous and current month based on Hasura's
+latest complete date; incremental runs only require the Arbitrum/Ethereum
+`crossChainComplete` gate.
 
 To clear only the local artifact bucket while keeping the rest of the compose
 stack running:
@@ -137,9 +138,10 @@ Most variables have local defaults. Override these when needed:
   startup wrapper derives `ENVIO_INDEXER_PORT` from this value.
 - `PUBLISHER_PUBLIC_START_DATE`, `PUBLISHER_LOCK_TTL_MS`,
   `PUBLISHER_START_DATE`, and `PUBLISHER_END_DATE`: publisher range controls. If
-  no manifest exists, publishing starts at `2022-05-01`; otherwise it regenerates
-  the previous and current month. A fresh `v2/publisher.lock` makes overlapping
-  publisher runs exit successfully without writing artifacts.
+  no manifest exists, publishing starts at `2022-05-01`; otherwise it backfills
+  unpublished months and regenerates at least the previous and current month. A
+  fresh `v2/publisher.lock` makes overlapping publisher runs exit successfully
+  without writing artifacts.
 - `INDEXER_DEPLOYMENT_ID`: deployment identifier stamped into the internal
   manifest. `pnpm run compose:publish` sets it to the latest local git commit
   hash. If running Docker Compose directly, set it manually or provide

--- a/docs/railway-metrics-api.md
+++ b/docs/railway-metrics-api.md
@@ -231,9 +231,9 @@ The publisher writes `v2/publisher.lock` before reading Hasura. If a new cron
 run starts while a previous publish still holds a fresh lock, the new run exits
 successfully without writing artifacts. If no manifest exists, the publisher
 creates the initial backfill from `PUBLISHER_PUBLIC_START_DATE`; once a manifest
-exists, the same cron job publishes an incremental refresh for the previous and
-current month based on Hasura's latest complete date. If a publish crashes, a
-later run can take over after the lock expires.
+exists, the same cron job backfills any unpublished months and regenerates at
+least the previous and current month based on Hasura's latest complete date. If a
+publish crashes, a later run can take over after the lock expires.
 For the first publish of an `INDEXER_DEPLOYMENT_ID`, publisher bounds require
 every supported chain id to be present in `chainsIndexed`. Once that deployment
 has published snapshots, incremental bounds use `crossChainComplete=true`, which

--- a/docs/railway-metrics-api.md
+++ b/docs/railway-metrics-api.md
@@ -196,8 +196,6 @@ publisher writes immutable monthly JSON shards before publishing the manifest.
 - Required `ARTIFACT_SECRET_ACCESS_KEY`: bucket secret key.
 - Optional `PUBLISHER_PUBLIC_START_DATE`: first public API date, default
   `2022-05-01`.
-- Optional `PUBLISHER_LOOKBACK_DAYS`: number of already-published days to
-  regenerate when catching up from the existing manifest latest date.
 - Optional `PUBLISHER_LOCK_TTL_MS`: S3 lock timeout for overlapping cron runs. The
   documented default is 12 hours (`43200000`) so a slow first bootstrap is not
   overtaken by the next hourly cron.
@@ -233,8 +231,9 @@ The publisher writes `v2/publisher.lock` before reading Hasura. If a new cron
 run starts while a previous publish still holds a fresh lock, the new run exits
 successfully without writing artifacts. If no manifest exists, the publisher
 creates the initial backfill from `PUBLISHER_PUBLIC_START_DATE`; once a manifest
-exists, the same cron job publishes an incremental refresh with the configured
-lookback. If a publish crashes, a later run can take over after the lock expires.
+exists, the same cron job publishes an incremental refresh for the previous and
+current month based on Hasura's latest complete date. If a publish crashes, a
+later run can take over after the lock expires.
 For the first publish of an `INDEXER_DEPLOYMENT_ID`, publisher bounds require
 every supported chain id to be present in `chainsIndexed`. Once that deployment
 has published snapshots, incremental bounds use `crossChainComplete=true`, which

--- a/packages/metrics-artifacts/src/index.ts
+++ b/packages/metrics-artifacts/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./date-ranges.js";
 export * from "./legacy-shape.js";
 export * from "./openapi.js";
-export { CHAIN_NAMES } from "./types.js";
 export type * from "./types.js";
+export { CHAIN_NAMES } from "./types.js";

--- a/packages/metrics-artifacts/src/legacy-shape.ts
+++ b/packages/metrics-artifacts/src/legacy-shape.ts
@@ -26,7 +26,10 @@ export const REQUIRED_CHAIN_IDS_FOR_COMPLETE: number[] = [
 ];
 
 const CHAIN_ID_TO_NAME = new Map<number, ChainName>(
-  Object.entries(CHAIN_IDS_BY_NAME).map(([chainName, chainId]) => [chainId, chainName as ChainName]),
+  Object.entries(CHAIN_IDS_BY_NAME).map(([chainName, chainId]) => [
+    chainId,
+    chainName as ChainName,
+  ]),
 );
 
 function isChainName(value: string): value is ChainName {
@@ -152,9 +155,7 @@ export function buildDailyMetric(input: {
     const supplies = ohmSupplyByChain[chain];
     treasuryMarketValueComponents[chain] = sum(assets.map((asset) => asset.value));
     treasuryLiquidBackingComponents[chain] = sum(
-      assets
-        .filter((asset) => asset.isLiquid)
-        .map((asset) => asset.valueExcludingOhm),
+      assets.filter((asset) => asset.isLiquid).map((asset) => asset.valueExcludingOhm),
     );
     ohmTotalSupplyComponents[chain] = sum(
       supplies.filter((supply) => supply.type === "Total Supply").map((supply) => supply.balance),

--- a/packages/metrics-artifacts/src/openapi.ts
+++ b/packages/metrics-artifacts/src/openapi.ts
@@ -84,7 +84,9 @@ export function getOpenApiDocument(): {
         get: {
           summary: "Published date bounds",
           responses: {
-            "200": jsonResponse("Earliest/latest dates, maximum v2 range, and latest per-chain indexing progress."),
+            "200": jsonResponse(
+              "Earliest/latest dates, maximum v2 range, and latest per-chain indexing progress.",
+            ),
           },
         },
       },
@@ -160,7 +162,9 @@ export function getOpenApiDocument(): {
         get: deprecatedOperation("Latest protocol metrics using the legacy protocolMetrics alias."),
       },
       "/operations/earliest/protocolMetrics": {
-        get: deprecatedOperation("Earliest protocol metrics using the legacy protocolMetrics alias."),
+        get: deprecatedOperation(
+          "Earliest protocol metrics using the legacy protocolMetrics alias.",
+        ),
       },
       "/operations/paginated/protocolMetrics": {
         get: deprecatedOperation(

--- a/packages/metrics-artifacts/src/types.ts
+++ b/packages/metrics-artifacts/src/types.ts
@@ -1,4 +1,11 @@
-export const CHAIN_NAMES = ["Arbitrum", "Ethereum", "Fantom", "Polygon", "Base", "Berachain"] as const;
+export const CHAIN_NAMES = [
+  "Arbitrum",
+  "Ethereum",
+  "Fantom",
+  "Polygon",
+  "Base",
+  "Berachain",
+] as const;
 
 export type ChainName = (typeof CHAIN_NAMES)[number];
 

--- a/packages/metrics-artifacts/tests/date-ranges.test.ts
+++ b/packages/metrics-artifacts/tests/date-ranges.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
-
-import { monthKeysForRange, resolveDateRange } from "../src";
 import type { Manifest } from "../src";
+import { monthKeysForRange, resolveDateRange } from "../src";
 
 const manifest: Manifest = {
   schemaVersion: "1.0.0",
@@ -20,9 +19,9 @@ describe("date range resolution", () => {
   });
 
   test("rejects end date before start date", () => {
-    expect(() =>
-      resolveDateRange({ start: "2026-06-01", end: "2026-05-20", manifest }),
-    ).toThrow(/end must be greater than or equal to start/i);
+    expect(() => resolveDateRange({ start: "2026-06-01", end: "2026-05-20", manifest })).toThrow(
+      /end must be greater than or equal to start/i,
+    );
   });
 
   test("enforces max range only when requested", () => {
@@ -48,8 +47,10 @@ describe("date range resolution", () => {
   });
 
   test("selects month shards across month and year boundaries", () => {
-    expect(
-      monthKeysForRange({ start: "2025-12-31", end: "2026-02-01", days: 33 }),
-    ).toEqual(["2025-12", "2026-01", "2026-02"]);
+    expect(monthKeysForRange({ start: "2025-12-31", end: "2026-02-01", days: 33 })).toEqual([
+      "2025-12",
+      "2026-01",
+      "2026-02",
+    ]);
   });
 });

--- a/packages/metrics-artifacts/tests/legacy-shape.test.ts
+++ b/packages/metrics-artifacts/tests/legacy-shape.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-
+import type { OhmSupply, TreasuryAsset } from "../src";
 import {
   buildDailyMetric,
   emptyChainValues,
@@ -7,7 +7,6 @@ import {
   groupOhmSupplyByChain,
   groupTreasuryAssetsByChain,
 } from "../src";
-import type { OhmSupply, TreasuryAsset } from "../src";
 
 const treasuryAsset: TreasuryAsset = {
   id: "asset-1",
@@ -115,7 +114,13 @@ describe("legacy-compatible metric shape", () => {
     expect(metric.chainsMissing).toEqual([42161, 250, 137, 8453, 80094]);
     expect(metric.crossChainComplete).toBe(false);
     expect(metric._meta?.chainsComplete).toEqual(["Ethereum"]);
-    expect(metric._meta?.chainsFailed).toEqual(["Arbitrum", "Fantom", "Polygon", "Base", "Berachain"]);
+    expect(metric._meta?.chainsFailed).toEqual([
+      "Arbitrum",
+      "Fantom",
+      "Polygon",
+      "Base",
+      "Berachain",
+    ]);
   });
 
   test("marks cross-chain data complete when Arbitrum and Ethereum are indexed", () => {

--- a/packages/metrics-artifacts/tests/openapi.test.ts
+++ b/packages/metrics-artifacts/tests/openapi.test.ts
@@ -5,7 +5,10 @@ import { getOpenApiDocument } from "../src";
 describe("OpenAPI document", () => {
   test("documents v2, legacy operations, deprecated operations, and atBlock 501 responses", () => {
     const document = getOpenApiDocument() as {
-      paths: Record<string, { get?: { deprecated?: boolean; responses?: Record<string, unknown> } }>;
+      paths: Record<
+        string,
+        { get?: { deprecated?: boolean; responses?: Record<string, unknown> } }
+      >;
     };
 
     expect(document.paths["/v2/bounds"]).toBeDefined();
@@ -14,8 +17,14 @@ describe("OpenAPI document", () => {
     expect(document.paths["/v2/ohm-supply/daily"]).toBeDefined();
     expect(document.paths["/operations/paginated/metrics"]?.get?.deprecated).toBe(true);
     expect(document.paths["/operations/atBlock/metrics"]?.get?.responses?.["501"]).toBeDefined();
-    expect(document.paths["/operations/atBlock/tokenRecords"]?.get?.responses?.["501"]).toBeDefined();
-    expect(document.paths["/operations/atBlock/tokenSupplies"]?.get?.responses?.["501"]).toBeDefined();
-    expect(document.paths["/operations/atBlock/internal/protocolMetrics"]?.get?.responses?.["501"]).toBeDefined();
+    expect(
+      document.paths["/operations/atBlock/tokenRecords"]?.get?.responses?.["501"],
+    ).toBeDefined();
+    expect(
+      document.paths["/operations/atBlock/tokenSupplies"]?.get?.responses?.["501"],
+    ).toBeDefined();
+    expect(
+      document.paths["/operations/atBlock/internal/protocolMetrics"]?.get?.responses?.["501"],
+    ).toBeDefined();
   });
 });

--- a/railway-hasura.json
+++ b/railway-hasura.json
@@ -3,10 +3,7 @@
   "build": {
     "builder": "DOCKERFILE",
     "dockerfilePath": "Dockerfile-hasura",
-    "watchPatterns": [
-      "/Dockerfile-hasura",
-      "/railway-hasura.json"
-    ]
+    "watchPatterns": ["/Dockerfile-hasura", "/railway-hasura.json"]
   },
   "deploy": {
     "healthcheckPath": "/healthz",

--- a/tests/monorepo/indexer-layout.test.ts
+++ b/tests/monorepo/indexer-layout.test.ts
@@ -36,7 +36,9 @@ describe("indexer monorepo layout", () => {
     };
 
     expect(packageJson.scripts["env:check"]).toBe("tsx src/start-envio.ts check");
-    expect(packageJson.scripts["envio:dev"]).toBe(`ENVIO_TUI=\${ENVIO_TUI:-false} tsx src/start-envio.ts dev`);
+    expect(packageJson.scripts["envio:dev"]).toBe(
+      `ENVIO_TUI=\${ENVIO_TUI:-false} tsx src/start-envio.ts dev`,
+    );
     expect(packageJson.scripts["envio:start"]).toBe("tsx src/start-envio.ts start");
   });
 

--- a/tests/railway/compose.test.ts
+++ b/tests/railway/compose.test.ts
@@ -2,7 +2,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 
 function serviceBlock(compose: string, serviceName: string): string {
-  const match = compose.match(new RegExp(`\\n  ${serviceName}:\\n([\\s\\S]*?)(?=\\n  [a-zA-Z0-9_-]+:\\n|\\nvolumes:\\n|\\nnetworks:\\n|$)`));
+  const match = compose.match(
+    new RegExp(
+      `\\n  ${serviceName}:\\n([\\s\\S]*?)(?=\\n  [a-zA-Z0-9_-]+:\\n|\\nvolumes:\\n|\\nnetworks:\\n|$)`,
+    ),
+  );
   if (match === null) {
     throw new Error(`Missing service ${serviceName}`);
   }
@@ -44,8 +48,12 @@ describe("local Docker Compose stack", () => {
 
     expect(serviceBlock(compose, "minio")).toContain("/minio/health/ready");
     expect(serviceBlock(compose, "minio-init")).toContain("condition: service_healthy");
-    expect(serviceBlock(compose, "metrics-api")).toContain("condition: service_completed_successfully");
-    expect(serviceBlock(compose, "metrics-publisher")).toContain("condition: service_completed_successfully");
+    expect(serviceBlock(compose, "metrics-api")).toContain(
+      "condition: service_completed_successfully",
+    );
+    expect(serviceBlock(compose, "metrics-publisher")).toContain(
+      "condition: service_completed_successfully",
+    );
     expect(serviceBlock(compose, "indexer")).toContain("condition: service_healthy");
     expect(serviceBlock(compose, "indexer")).toContain("hasura:");
   });
@@ -53,12 +61,16 @@ describe("local Docker Compose stack", () => {
   test("includes indexer in the default stack and runs publisher as an explicit profile", () => {
     const compose = readFileSync("docker-compose.yml", "utf8");
     const doc = readFileSync("docs/local-compose.md", "utf8");
-    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { scripts: Record<string, string> };
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
 
     expect(serviceBlock(compose, "metrics-publisher")).toContain("publish");
     expect(serviceBlock(compose, "indexer")).not.toContain("profiles:");
     expect(doc).toContain("only `metrics-api` is reachable from the host");
-    expect(doc).toContain("docker compose up --build postgres hasura minio minio-init indexer metrics-api");
+    expect(doc).toContain(
+      "docker compose up --build postgres hasura minio minio-init indexer metrics-api",
+    );
     expect(doc).toContain("pnpm run compose:publish");
     expect(packageJson.scripts["compose:up"]).toBe(
       "docker compose up --build postgres hasura minio minio-init indexer metrics-api",
@@ -74,8 +86,12 @@ describe("local Docker Compose stack", () => {
     const packageJson = readFileSync("package.json", "utf8");
 
     expect(packageJson).toContain('"compose:core": "docker compose up postgres hasura indexer"');
-    expect(packageJson).toContain('"compose:api": "docker compose up --build minio minio-init metrics-api"');
-    expect(packageJson).toContain('"compose:api:rebuild": "docker compose up --build --no-deps metrics-api"');
+    expect(packageJson).toContain(
+      '"compose:api": "docker compose up --build minio minio-init metrics-api"',
+    );
+    expect(packageJson).toContain(
+      '"compose:api:rebuild": "docker compose up --build --no-deps metrics-api"',
+    );
     expect(packageJson).toContain('"compose:bucket:clear": "docker compose run --rm --no-deps');
     expect(doc).toContain("## Split Workflow");
     expect(doc).toContain("in the foreground");
@@ -84,7 +100,9 @@ describe("local Docker Compose stack", () => {
     expect(doc).toContain("pnpm run compose:api:rebuild");
     expect(doc).toContain("pnpm run compose:bucket:clear");
     expect(doc).toContain("pnpm run compose:publish");
-    expect(doc).toContain("This rebuilds and starts only the one-shot `metrics-publisher` container");
+    expect(doc).toContain(
+      "This rebuilds and starts only the one-shot `metrics-publisher` container",
+    );
   });
 
   test("documents and wires stack variables without unsupported Envio env knobs", () => {

--- a/tests/railway/config.test.ts
+++ b/tests/railway/config.test.ts
@@ -26,13 +26,25 @@ describe("Railway config-as-code", () => {
       deploy: { cronSchedule: string; restartPolicyType: string };
     };
     const api = JSON.parse(readFileSync("railway-metrics-api.json", "utf8")) as {
-      deploy: { healthcheckPath: string; restartPolicyMaxRetries: number; restartPolicyType: string };
+      deploy: {
+        healthcheckPath: string;
+        restartPolicyMaxRetries: number;
+        restartPolicyType: string;
+      };
     };
     const hasura = JSON.parse(readFileSync("railway-hasura.json", "utf8")) as {
-      deploy: { healthcheckPath: string; restartPolicyMaxRetries: number; restartPolicyType: string };
+      deploy: {
+        healthcheckPath: string;
+        restartPolicyMaxRetries: number;
+        restartPolicyType: string;
+      };
     };
     const indexer = JSON.parse(readFileSync("railway-indexer.json", "utf8")) as {
-      deploy: { healthcheckPath: string; restartPolicyMaxRetries: number; restartPolicyType: string };
+      deploy: {
+        healthcheckPath: string;
+        restartPolicyMaxRetries: number;
+        restartPolicyType: string;
+      };
     };
 
     expect(publisher.deploy.cronSchedule).toBe("15 * * * *");
@@ -103,8 +115,12 @@ describe("Railway config-as-code", () => {
 
     expect(doc).toContain("Do not set `ENVIO_PG_SCHEMA` on Railway");
     expect(doc).toContain("Railway indexer startup runs `envio start -r`");
-    expect(doc).toContain("Published artifact snapshots and the metrics API are the handover boundary");
-    expect(doc).not.toContain("copies Railway's runtime `RAILWAY_DEPLOYMENT_ID` into `ENVIO_PG_SCHEMA`");
+    expect(doc).toContain(
+      "Published artifact snapshots and the metrics API are the handover boundary",
+    );
+    expect(doc).not.toContain(
+      "copies Railway's runtime `RAILWAY_DEPLOYMENT_ID` into `ENVIO_PG_SCHEMA`",
+    );
     expect(doc).toContain("indexer startup wrapper derives `ENVIO_INDEXER_PORT`");
     expect(doc).toContain(`\${{hasura.RAILWAY_PRIVATE_DOMAIN}}:\${{hasura.PORT}}/v1/graphql`);
     expect(doc).toContain(`\${{hasura.RAILWAY_PRIVATE_DOMAIN}}:\${{hasura.PORT}}/v1/metadata`);
@@ -118,7 +134,11 @@ describe("Railway config-as-code", () => {
     expect(dockerignore.split(/\r?\n/)).toContain(".pnpm-store");
     expect(dockerignore.split(/\r?\n/)).toContain("**/.envio");
 
-    for (const dockerfile of ["Dockerfile-indexer", "Dockerfile-metrics-api", "Dockerfile-metrics-publisher"]) {
+    for (const dockerfile of [
+      "Dockerfile-indexer",
+      "Dockerfile-metrics-api",
+      "Dockerfile-metrics-publisher",
+    ]) {
       const content = readFileSync(dockerfile, "utf8");
       expect(content).toContain("@sha256:");
       expect(content).toContain("apt-get install -y --no-install-recommends ca-certificates");
@@ -128,14 +148,16 @@ describe("Railway config-as-code", () => {
       expect(content).toContain("pnpm --version");
       expect(content).toContain("pnpm install --frozen-lockfile");
       expect(content).toContain("/usr/local/lib/node_modules/npm");
-      expect(content).not.toContain("node\", \"--version");
+      expect(content).not.toContain('node", "--version');
       expect(content).toContain("USER node");
     }
 
     expect(readFileSync("Dockerfile-hasura", "utf8")).toContain("--only-upgrade");
     expect(readFileSync("Dockerfile-hasura", "utf8")).not.toContain("apt-get upgrade");
     expect(readFileSync("Dockerfile-indexer", "utf8")).toContain("envio:start");
-    expect(readFileSync("Dockerfile-indexer", "utf8")).toContain("chown -R node:node apps/indexer/.envio");
+    expect(readFileSync("Dockerfile-indexer", "utf8")).toContain(
+      "chown -R node:node apps/indexer/.envio",
+    );
     const metricsApiDockerfile = readFileSync("Dockerfile-metrics-api", "utf8");
     const metricsPublisherDockerfile = readFileSync("Dockerfile-metrics-publisher", "utf8");
     expect(metricsApiDockerfile).toContain("pnpm --dir apps/indexer codegen");
@@ -151,7 +173,7 @@ describe("Railway config-as-code", () => {
 
     expect(content).toContain("HASURA_GRAPHQL_DATABASE_URL:?");
     expect(content).toContain("HASURA_GRAPHQL_ADMIN_SECRET:?");
-    expect(content).toContain("export HASURA_GRAPHQL_SERVER_PORT=\\\"$PORT\\\"");
+    expect(content).toContain('export HASURA_GRAPHQL_SERVER_PORT=\\"$PORT\\"');
     expect(content).toContain("HASURA_GRAPHQL_SERVER_PORT must match PORT when set");
     expect(content).toContain("USER hasura");
     expect(content).toContain("ENTRYPOINT []");
@@ -162,8 +184,12 @@ describe("Railway config-as-code", () => {
     const workflow = readFileSync(".github/workflows/security-scan.yml", "utf8");
     const packageJson = readFileSync("package.json", "utf8");
 
-    expect(workflow).toContain("aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1");
-    expect(workflow).toContain("docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd");
+    expect(workflow).toContain(
+      "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1",
+    );
+    expect(workflow).toContain(
+      "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd",
+    );
     expect(workflow.match(/ignore-unfixed: true/g)?.length).toBe(4);
 
     for (const [name, dockerfile] of [


### PR DESCRIPTION
## Summary

Fixes the metrics publisher incremental refresh path so it regenerates complete monthly artifact shards instead of overwriting a month with only the lookback-window rows.

## Root Cause

After a deployment had already handed over, the publisher used a short lookback range but still wrote month-level artifacts. A June refresh over only June 15-17 could therefore replace the whole `2026-06.json` shard with those three dates, causing June 1-14 to be served as missing/empty.

## Changes

- Regenerate the current month plus previous month for incremental publishes.
- Skip publishing with `not_data_ready` if daily metric rows are not contiguous for the expanded range.
- Strengthen publisher tests to assert regenerated metrics, treasury asset, and OHM supply shards across normal and month-boundary cases.
- Apply Biome formatting and align CI to run `pnpm run check` so format/import diagnostics are enforced in GitHub.

## Validation

- `pnpm install --frozen-lockfile`
- Red/green publisher regression run against the old and fixed implementations
- `pnpm --dir apps/metrics-publisher test`
- `pnpm exec biome check apps/metrics-publisher/src/publisher.ts apps/metrics-publisher/tests/publisher.test.ts`
- `pnpm run validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics publisher now skips publishing when artifacts already exist but newly fetched daily metrics are missing for the computed publish range.
* **Bug Fixes**
  * Metrics publisher publish-range logic was updated: range start/end are derived from published/public dates (incremental refresh of prior/current month) instead of lookback overlap.
* **Documentation**
  * Updated local and Railway metrics publisher docs to remove `PUBLISHER_LOOKBACK_DAYS` and reflect the new incremental behavior.
* **Chores**
  * Updated CI lint command and refined Railway Hasura watch patterns.
* **Tests**
  * Refreshed client, release/check, OpenAPI, and metrics publisher assertions to match updated outputs/ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->