### PR TITLE
Avoid implicit RPC fallbacks

### DIFF
--- a/Dockerfile-hasura
+++ b/Dockerfile-hasura
@@ -37,6 +37,7 @@ RUN DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get update \
     python3.10 \
     python3.10-minimal \
     sed \
+    tar \
     util-linux \
   && rm -rf /var/lib/apt/lists/*
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE=false

--- a/Dockerfile-indexer
+++ b/Dockerfile-indexer
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 RUN mkdir -p /corepack /pnpm \
   && corepack enable \
-  && corepack prepare pnpm@10.34.3 --activate \
+  && corepack prepare pnpm@11.9.0 --activate \
   && pnpm --version \
   && chown -R node:node /corepack /pnpm
 

--- a/Dockerfile-metrics-api
+++ b/Dockerfile-metrics-api
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 RUN mkdir -p /corepack /pnpm \
   && corepack enable \
-  && corepack prepare pnpm@10.34.3 --activate \
+  && corepack prepare pnpm@11.9.0 --activate \
   && pnpm --version \
   && chown -R node:node /corepack /pnpm
 

--- a/Dockerfile-metrics-publisher
+++ b/Dockerfile-metrics-publisher
@@ -14,7 +14,7 @@ RUN apt-get update \
 
 RUN mkdir -p /corepack /pnpm \
   && corepack enable \
-  && corepack prepare pnpm@10.34.3 --activate \
+  && corepack prepare pnpm@11.9.0 --activate \
   && pnpm --version \
   && chown -R node:node /corepack /pnpm
 

--- a/apps/indexer/src/snapshot/chains/rpc.ts
+++ b/apps/indexer/src/snapshot/chains/rpc.ts
@@ -4,7 +4,11 @@ export function rpcUrls(
   defaultFallbackUrls: string[] = [],
 ): string[] {
   const envPrefix = `ENVIO_${prefix}`;
-  const configuredPrimary = process.env[`${envPrefix}_RPC_URL`]?.trim();
+  const configuredPrimaryInput = process.env[`${envPrefix}_RPC_URL`]?.trim();
+  const configuredPrimary =
+    configuredPrimaryInput && configuredPrimaryInput.length > 0
+      ? configuredPrimaryInput
+      : undefined;
   const primary = configuredPrimary ?? defaultUrl;
   if (!configuredPrimary) {
     console.warn(
@@ -16,5 +20,6 @@ export function rpcUrls(
     .split(",")
     .map((url) => url.trim())
     .filter((url) => url.length > 0);
+  if (configuredPrimary) return [primary, ...fallbacks];
   return [primary, ...(fallbacks.length > 0 ? fallbacks : defaultFallbackUrls)];
 }

--- a/apps/indexer/tests/snapshot/rpc.test.ts
+++ b/apps/indexer/tests/snapshot/rpc.test.ts
@@ -45,4 +45,17 @@ describe("rpcUrls", () => {
       "Using default public archive RPC for ARBITRUM. Set ENVIO_ARBITRUM_RPC_URL for backfills.",
     );
   });
+
+  test("treats a whitespace-only primary as unset", () => {
+    process.env.ENVIO_ARBITRUM_RPC_URL = "   ";
+    process.env.ENVIO_ARBITRUM_FALLBACK_RPC_URLS = "";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      rpcUrls("ARBITRUM", "https://default.example.com", ["https://public-fallback.example.com"]),
+    ).toEqual(["https://default.example.com", "https://public-fallback.example.com"]);
+    expect(warn).toHaveBeenCalledWith(
+      "Using default public archive RPC for ARBITRUM. Set ENVIO_ARBITRUM_RPC_URL for backfills.",
+    );
+  });
 });

--- a/apps/indexer/tests/snapshot/rpc.test.ts
+++ b/apps/indexer/tests/snapshot/rpc.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { rpcUrls } from "../../src/snapshot/chains/rpc";
+
+describe("rpcUrls", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  test("uses only the configured primary when no explicit fallback is set", () => {
+    process.env.ENVIO_ARBITRUM_RPC_URL = "https://alchemy.example.com";
+    process.env.ENVIO_ARBITRUM_FALLBACK_RPC_URLS = "";
+
+    expect(
+      rpcUrls("ARBITRUM", "https://default.example.com", ["https://public-fallback.example.com"]),
+    ).toEqual(["https://alchemy.example.com"]);
+  });
+
+  test("keeps explicit fallbacks with a configured primary", () => {
+    process.env.ENVIO_ARBITRUM_RPC_URL = "https://alchemy.example.com";
+    process.env.ENVIO_ARBITRUM_FALLBACK_RPC_URLS =
+      "https://fallback-one.example.com, https://fallback-two.example.com";
+
+    expect(
+      rpcUrls("ARBITRUM", "https://default.example.com", ["https://public-fallback.example.com"]),
+    ).toEqual([
+      "https://alchemy.example.com",
+      "https://fallback-one.example.com",
+      "https://fallback-two.example.com",
+    ]);
+  });
+
+  test("uses default fallbacks only when the primary also falls back to default", () => {
+    process.env.ENVIO_ARBITRUM_RPC_URL = "";
+    process.env.ENVIO_ARBITRUM_FALLBACK_RPC_URLS = "";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      rpcUrls("ARBITRUM", "https://default.example.com", ["https://public-fallback.example.com"]),
+    ).toEqual(["https://default.example.com", "https://public-fallback.example.com"]);
+    expect(warn).toHaveBeenCalledWith(
+      "Using default public archive RPC for ARBITRUM. Set ENVIO_ARBITRUM_RPC_URL for backfills.",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -63,5 +63,5 @@
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@10.34.3"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,10 @@ onlyBuiltDependencies:
   # `strictDepBuilds: true` rejects the install with ERR_PNPM_IGNORED_BUILDS.
   # Pinned to the patched 0.28.1 (see esbuild override below + GHSA fixes).
   - "esbuild@0.28.1"
+allowBuilds:
+  # pnpm 11 records approved dependency build scripts here. Keep this exact:
+  # esbuild is required by Vitest/Vite for native binary installation.
+  esbuild: true
 # All CVE overrides are range-scoped — `pkg@<fixed: fixed` only patches
 # resolutions that fall in the vulnerable range, leaving newer versions
 # alone. Unscoped overrides (e.g. `"pkg": "^X"`) are a footgun: they force


### PR DESCRIPTION
## Summary
- stop appending built-in public RPC fallbacks when a primary ENVIO_<CHAIN>_RPC_URL is configured
- keep explicit ENVIO_<CHAIN>_FALLBACK_RPC_URLS support with configured primaries
- add rpcUrls coverage for configured, explicit fallback, and default fallback cases

## Root cause
Configured primary RPC URLs were still combined with baked-in public fallback URLs. On Arbitrum, that allowed production snapshot RPC reads to fall through to the public Blast endpoint even when ENVIO_ARBITRUM_RPC_URL was set.

## Validation
- ../../node_modules/.bin/vitest run tests from apps/indexer
- ./node_modules/.bin/biome check apps/indexer/src/snapshot/chains/rpc.ts apps/indexer/tests/snapshot/rpc.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC URL handling by ignoring empty or whitespace-only configuration values.
  * When a primary RPC URL is explicitly set, it’s now prioritized first, followed by any configured fallback RPC URLs.
  * If custom RPC settings are missing (or empty), the app falls back to the default public RPC list and logs guidance.
* **Tests**
  * Expanded automated test coverage for RPC selection and warning behavior.
* **Chores**
  * Updated the build toolchain to pnpm@11.9.0 and adjusted workspace build permissions for required native dependency builds.
  * Added `tar` to the Hasura image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->