### PR TITLE
fix: index WETH-OHM POL by fee tier

### DIFF
--- a/apps/indexer/config.yaml
+++ b/apps/indexer/config.yaml
@@ -463,6 +463,7 @@ chains:
       - name: UniswapV3Pool
         address:
           - "0x88051b0eea095007d3bef21ab287be961f3d8598" # WETH-OHM
+          - "0x584eC2562b937C4AC0452184D8d83346382B5D3a" # WETH-OHM 1% (Treasury concentrated POL)
           - "0x0858e2B0F9D75f7300B38D64482aC2C8DF06a755" # OHM-sUSDS (also POL — NFT positions)
           - "0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa" # WETH-wstETH
           - "0x202A6012894Ae5c288eA824cbc8A9bfb26A49b93" # weETH-WETH

--- a/apps/indexer/src/handlers/Univ3NftPol.ts
+++ b/apps/indexer/src/handlers/Univ3NftPol.ts
@@ -43,17 +43,17 @@ export async function pushUniv3NftPol(
   if (!manager) return;
   if (blockNumber < BigInt(manager.startBlock)) return;
 
-  // Build a token-pair → pool lookup from this chain's univ3 handlers so we
-  // can match each NFT position to a pool we know about (and have indexed
-  // sqrtPriceX96 for).
+  // Build a token-pair + fee-tier → pool lookup from this chain's owned
+  // UniV3 handlers so positions in different pools for the same pair do not
+  // collapse into one row. Handlers without an explicit fee retain the
+  // pair-only fallback for chains that have a single configured pool per pair.
   const univ3Pools = new Map<string, { id: string; tokens: string[] }>();
-  for (const handler of config.liquidityHandlers) {
+  for (const handler of config.ownedLiquidityHandlers) {
     if (handler.kind !== "univ3") continue;
-    const sorted = [handler.tokens[0]?.toLowerCase(), handler.tokens[1]?.toLowerCase()]
-      .filter(Boolean)
-      .sort()
-      .join("/");
-    univ3Pools.set(sorted, { id: handler.id, tokens: handler.tokens });
+    univ3Pools.set(univ3PoolKey(handler.tokens, handler.fee), {
+      id: handler.id,
+      tokens: handler.tokens,
+    });
   }
   if (univ3Pools.size === 0) return;
 
@@ -89,8 +89,10 @@ export async function pushUniv3NftPol(
     };
     const aggregates = new Map<string, PoolAgg>();
     for (const position of result.positions) {
-      const pairKey = [position.token0, position.token1].sort().join("/");
-      const pool = univ3Pools.get(pairKey);
+      const pairKey = univ3PoolKey([position.token0, position.token1]);
+      const pool =
+        univ3Pools.get(univ3PoolKey([position.token0, position.token1], position.fee)) ??
+        univ3Pools.get(pairKey);
       if (!pool) continue;
 
       const state = await context.Univ3PoolState.get(`${config.chainId}-${addr(pool.id)}`);
@@ -210,4 +212,12 @@ export async function pushUniv3NftPol(
       }
     }
   }
+}
+
+export function univ3PoolKey(tokens: string[], fee?: number): string {
+  const pair = [tokens[0]?.toLowerCase(), tokens[1]?.toLowerCase()]
+    .filter(Boolean)
+    .sort()
+    .join("/");
+  return fee === undefined ? pair : `${pair}/${fee}`;
 }

--- a/apps/indexer/src/snapshot/chains/ethereum.ts
+++ b/apps/indexer/src/snapshot/chains/ethereum.ts
@@ -248,6 +248,7 @@ const AURA_VAULT_OHM_DAI_WETH = addr("0xF01e29461f1FCEdD82f5258Da006295E23b4Fab3
 const AURA_VAULT_OHM_WSTETH = addr("0x636024f9ddef77e625161b2ccf3a2adfbfad3615");
 
 const LP_UNISWAP_V3_WETH_OHM = addr("0x88051b0eea095007d3bef21ab287be961f3d8598");
+const LP_UNISWAP_V3_WETH_OHM_ONE_PERCENT = addr("0x584eC2562b937C4AC0452184D8d83346382B5D3a");
 const LP_UNISWAP_V3_OHM_SUSDS = addr("0x0858e2B0F9D75f7300B38D64482aC2C8DF06a755");
 const LP_UNISWAP_V3_WETH_WSTETH = addr("0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa");
 const LP_UNISWAP_V3_WEETH_WETH = addr("0x202A6012894Ae5c288eA824cbc8A9bfb26A49b93");
@@ -383,6 +384,7 @@ const names: Record<string, string> = {
   [LP_UNISWAP_V3_WETH_BTRFLY_V1]: "UniswapV3 WETH-BTRFLY V1",
   [LP_UNISWAP_V3_WETH_BTRFLY_V2]: "UniswapV3 WETH-BTRFLY V2",
   [LP_UNISWAP_V3_WETH_OHM]: "UniswapV3 WETH-OHM",
+  [LP_UNISWAP_V3_WETH_OHM_ONE_PERCENT]: "UniswapV3 1% WETH-OHM",
   [LP_UNISWAP_V3_OHM_SUSDS]: "UniswapV3 OHM-sUSDS",
   [LP_UNISWAP_V3_WETH_WSTETH]: "UniswapV3 WETH-wstETH",
 };
@@ -434,7 +436,19 @@ const univ3WethOhm: LiquidityHandler = {
   kind: "univ3",
   tokens: [ERC20_OHM_V2, ERC20_WETH],
   id: LP_UNISWAP_V3_WETH_OHM,
+  fee: 3000,
   startBlock: ERC20_OHM_V2_BLOCK,
+};
+
+// Treasury concentrated WETH-OHM position in the 1% fee-tier pool. This is
+// intentionally an owned-liquidity handler only: the smaller pool is POL but
+// should not become an OHM oracle candidate.
+const univ3WethOhmOnePercent: LiquidityHandler = {
+  kind: "univ3",
+  tokens: [ERC20_OHM_V2, ERC20_WETH],
+  id: LP_UNISWAP_V3_WETH_OHM_ONE_PERCENT,
+  fee: 10000,
+  startBlock: 25_000_000,
 };
 
 // OHM-sUSDS UniV3 pool (per inventory-ethereum.md §6). Treasury holds NFT
@@ -446,10 +460,15 @@ const univ3OhmSusds: LiquidityHandler = {
   kind: "univ3",
   tokens: [ERC20_OHM_V2, ERC20_SUSDS],
   id: LP_UNISWAP_V3_OHM_SUSDS,
+  fee: 3000,
   startBlock: LP_UNISWAP_V3_OHM_SUSDS_BLOCK,
 };
 
-const ownedLiquidityHandlers: LiquidityHandler[] = [univ3WethOhm, univ3OhmSusds];
+const ownedLiquidityHandlers: LiquidityHandler[] = [
+  univ3WethOhm,
+  univ3WethOhmOnePercent,
+  univ3OhmSusds,
+];
 
 // Cooler Loans clearinghouses. Each clearinghouse's principal receivable is
 // added to the snapshot as a DAI / USDS TokenRecord priced via the

--- a/apps/indexer/src/snapshot/types.ts
+++ b/apps/indexer/src/snapshot/types.ts
@@ -218,7 +218,14 @@ export type LiquidityHandler =
       startBlock?: number;
     }
   | { kind: "univ2"; id: string; tokens: string[]; startBlock?: number }
-  | { kind: "univ3"; id: string; tokens: string[]; startBlock?: number }
+  | {
+      kind: "univ3";
+      id: string;
+      tokens: string[];
+      /** Pool fee tier in hundredths of a basis point. Required when the same pair has multiple pools. */
+      fee?: number;
+      startBlock?: number;
+    }
   | { kind: "univ3-quoter"; id: string; quoter: string; tokens: string[]; startBlock?: number }
   | { kind: "balancer"; id: Bytes32; vault: string; tokens: string[]; startBlock?: number }
   | {

--- a/apps/indexer/tests/handlers/Univ3NftPol.test.ts
+++ b/apps/indexer/tests/handlers/Univ3NftPol.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+
+import { univ3PoolKey } from "../../src/handlers/Univ3NftPol";
+
+describe("univ3PoolKey", () => {
+  const ohm = "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5";
+  const weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+
+  test("distinguishes fee-tier pools for the same token pair", () => {
+    expect(univ3PoolKey([ohm, weth], 3000)).not.toBe(univ3PoolKey([ohm, weth], 10000));
+  });
+
+  test("is independent of token order", () => {
+    expect(univ3PoolKey([ohm, weth], 10000)).toBe(univ3PoolKey([weth, ohm], 10000));
+  });
+});


### PR DESCRIPTION
## Summary

- match Treasury Uniswap V3 NFT positions by token pair **and fee tier**
- register the OHM/WETH 1% pool (`0x584eC2562b937C4AC0452184D8d83346382B5D3a`) as owned liquidity
- keep the smaller 1% pool out of OHM oracle candidates
- add regression coverage for fee-tier separation and token-order independence

## Why

The Treasury holds active concentrated position NFT `#1327814` in the OHM/WETH 1% pool. The indexer currently keys known Uni V3 pools by token pair only, so that position is valued against and aggregated into the configured 0.3% pool (`0x88051B...`). This prevents the 1% position from appearing as its own POL row and applies the wrong pool state to its liquidity math.

On-chain verification:

- NFT `#1327814` owner: Treasury Safe `0x245cc372C84B3645Bf0Ffe6538620B04a217988B`
- position fee: `10000` (1%)
- 1% pool from the canonical Uniswap V3 factory: `0x584eC2562b937C4AC0452184D8d83346382B5D3a`
- existing configured pool fee: `3000` (0.3%)

## Validation

- `pnpm run codegen`
- `pnpm run validate`
- 252 tests passed; 3 existing tests skipped
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking treasury-owned WETH–OHM liquidity in the Uniswap v3 1% fee-tier pool.
  * Improved liquidity position matching across pools with different fee tiers.

* **Bug Fixes**
  * Ensured token order does not affect Uniswap v3 pool identification.

* **Tests**
  * Added coverage for fee-tier-specific and order-independent pool matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->