### PR TITLE
fix(indexer): harden RPC retries and refresh Envio

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.2.1",
+    "envio": "3.3.2",
     "viem": "2.53.1"
   },
   "devDependencies": {

--- a/apps/indexer/src/handlers/KodiakLps.ts
+++ b/apps/indexer/src/handlers/KodiakLps.ts
@@ -52,6 +52,7 @@ indexer.contractRegister(
   {
     contract: "KodiakLp",
     event: "Transfer",
+    where: buildLpTransferWhere,
   },
   async ({ event, context }) => {
     const config = CHAIN_CONFIGS[event.chainId as ChainId];

--- a/apps/indexer/src/snapshot/rpc-client.ts
+++ b/apps/indexer/src/snapshot/rpc-client.ts
@@ -167,9 +167,9 @@ function isRetryableRpcError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const name = "name" in error ? String(error.name) : "";
   if (name === "BlockNotFoundError") return true;
-  const code = "code" in error ? Number(error.code) : undefined;
+  const code = "code" in error ? toNumber(error.code) : undefined;
   if (name === "InternalRpcError" || code === INTERNAL_RPC_ERROR_CODE) return true;
-  const status = "status" in error ? Number(error.status) : undefined;
+  const status = "status" in error ? toNumber(error.status) : undefined;
   if (status && RETRYABLE_STATUSES.has(status)) return true;
   const details = "details" in error ? String(error.details) : "";
   const message = "message" in error ? String(error.message) : "";
@@ -182,6 +182,10 @@ function isRetryableRpcError(error: unknown): boolean {
     return true;
   }
   return "cause" in error ? isRetryableRpcError(error.cause) : false;
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === "number" || typeof value === "string" ? Number(value) : undefined;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/apps/indexer/src/snapshot/rpc-client.ts
+++ b/apps/indexer/src/snapshot/rpc-client.ts
@@ -33,6 +33,7 @@ const VIEM_CHAIN_BY_ID: Record<ChainId, Chain> = {
 
 const clients = new Map<number, PublicClient>();
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const INTERNAL_RPC_ERROR_CODE = -32603;
 const MAX_RPC_ATTEMPTS = 6;
 const BASE_RETRY_DELAY_MS = 1_000;
 const DEFAULT_HTTP_BATCH_SIZE = 10;
@@ -166,6 +167,8 @@ function isRetryableRpcError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const name = "name" in error ? String(error.name) : "";
   if (name === "BlockNotFoundError") return true;
+  const code = "code" in error ? Number(error.code) : undefined;
+  if (name === "InternalRpcError" || code === INTERNAL_RPC_ERROR_CODE) return true;
   const status = "status" in error ? Number(error.status) : undefined;
   if (status && RETRYABLE_STATUSES.has(status)) return true;
   const details = "details" in error ? String(error.details) : "";
@@ -173,6 +176,7 @@ function isRetryableRpcError(error: unknown): boolean {
   const shortMessage = "shortMessage" in error ? String(error.shortMessage) : "";
   if (details.includes("Too Many Requests")) return true;
   if (details.includes("compute units per second capacity")) return true;
+  if (details.trim().toLowerCase() === "internal error") return true;
   if (message.includes("compute units per second capacity")) return true;
   if (shortMessage.includes("could not be found") && shortMessage.includes("Block at number")) {
     return true;

--- a/apps/indexer/tests/snapshot/rpc.test.ts
+++ b/apps/indexer/tests/snapshot/rpc.test.ts
@@ -138,4 +138,15 @@ describe("retryRpc", () => {
     await expect(retryRpc(operation)).rejects.toBe(invalidInput);
     expect(operation).toHaveBeenCalledTimes(1);
   });
+
+  test.each([
+    { code: Symbol("code") },
+    { status: Symbol("status") },
+  ])("preserves errors with non-numeric RPC metadata", async (metadata) => {
+    const rpcError = Object.assign(new Error("RPC Request failed."), metadata);
+    const operation = vi.fn().mockRejectedValue(rpcError);
+
+    await expect(retryRpc(operation)).rejects.toBe(rpcError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/indexer/tests/snapshot/rpc.test.ts
+++ b/apps/indexer/tests/snapshot/rpc.test.ts
@@ -86,4 +86,56 @@ describe("retryRpc", () => {
     await expect(result).resolves.toBe("ok");
     expect(operation).toHaveBeenCalledTimes(2);
   });
+
+  test("retries provider internal errors wrapped as invalid input", async () => {
+    vi.useFakeTimers();
+    const rpcRequest = Object.assign(new Error("RPC Request failed."), {
+      name: "RpcRequestError",
+      details: "Internal error",
+    });
+    const invalidInput = Object.assign(new Error("Missing or invalid parameters."), {
+      name: "InvalidInputRpcError",
+      cause: rpcRequest,
+    });
+    const callExecution = Object.assign(new Error("Contract call failed."), {
+      name: "CallExecutionError",
+      cause: invalidInput,
+    });
+    const operation = vi.fn().mockRejectedValueOnce(callExecution).mockResolvedValueOnce("ok");
+
+    const result = retryRpc(operation);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(result).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    Object.assign(new Error("An internal error was received."), {
+      name: "InternalRpcError",
+    }),
+    Object.assign(new Error("RPC Request failed."), {
+      code: -32603,
+    }),
+  ])("retries canonical JSON-RPC internal errors", async (internalError) => {
+    vi.useFakeTimers();
+    const operation = vi.fn().mockRejectedValueOnce(internalError).mockResolvedValueOnce("ok");
+
+    const result = retryRpc(operation);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(result).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry genuine invalid-input errors", async () => {
+    const invalidInput = Object.assign(new Error("Missing or invalid parameters."), {
+      name: "InvalidInputRpcError",
+      details: "Invalid params",
+    });
+    const operation = vi.fn().mockRejectedValue(invalidInput);
+
+    await expect(retryRpc(operation)).rejects.toBe(invalidInput);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.2.1",
+    "envio": "3.3.2",
     "tsx": "4.22.4",
     "viem": "2.53.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
   tmp@<=0.2.3: 0.2.4
   undici@>=7.0.0 <7.24.0: 7.24.0
   yaml@<2.8.3: 2.8.3
-  body-parser@<1.20.3: 1.20.3
+  body-parser@<1.20.6: 1.20.6
   cookie@<0.7.0: 0.7.0
   express@<4.20.0: 4.20.0
   path-to-regexp@<0.1.13: 0.1.13
@@ -62,8 +62,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.2.1
-        version: 3.2.1(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.3.2
+        version: 3.3.2(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -92,8 +92,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.2.1
-        version: 3.2.1(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.3.2
+        version: 3.3.2(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       viem:
         specifier: 2.53.1
         version: 2.53.1(typescript@6.0.3)(zod@3.25.76)
@@ -313,49 +313,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-eQyd9kJCIz/4WCTjkjpQg80DA3pdneHP7qhJIVQ2ZG+Jew9o5XDG+uI0Y16AgGzZ6KGmJSJF6wyUaaAjJfbO1Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-l7lRMSoyIiIvKZgQPfgqg7H1xnrQ37A8yUp4S2ys47R8f/wSCSrmMaY1u7n6CxVYCpR9fajwy0/356UgwwhVKw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-kNiC/1fKuXnoSxp8yEsloDw4Ot/mIcNoYYGLl2CipSIpBtSuiBH5nb6eBcxnRZdKOwf5dKZtZ7MVPL9qJocNJw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-XDkvkBG/frS+xiZkJdY4KqOaoAwyxPdi2MysDQgF8NmZdssi32SWch0r4LTqKWLLlCBg9/R55POeXL5UAjg2wQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-DKnKJJSwsYtA7YT0EFGhFB5Eqoo42X0l0vZBv4lDuxngEXiiNjeLemXoKQVDzhcbILD7eyXNa5jWUc+2hpmkEg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-SwIgTAVM9QhCFPyHwL+e1yQ6o3paV6q25klESkXw+r/KW9QPhOOyA6Yr8nfnur3uqMTLJHAKHTLUnkyi/Nh7Aw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -839,14 +796,11 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
-  body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bowser@2.14.1:
@@ -1007,36 +961,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.2.1:
-    resolution: {integrity: sha512-PohM1rGjlNxV0W/BOQOitsVPua944B2t2M0p81x9VpsZOwNWc9SgPsEjIsV4ZJOIceJaHrmWZnfwaWubgDGKMg==}
+  envio-darwin-arm64@3.3.2:
+    resolution: {integrity: sha512-mJp85CHkAudLMyOBXXQ/XVOtzsG4YpyYDa2QO9jH4hCpiCRWrYcgtt4/c6rfjqH4fHhN69iQMp3wZDXV3ldwEA==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.2.1:
-    resolution: {integrity: sha512-70zjTm4tNFzhigja0mHqmG03JQu56e9JCTQR7zoEhVvwj47cSgAPmQIihpaPuDCcMIYibzrlW7pFKdnXAZp3fQ==}
+  envio-darwin-x64@3.3.2:
+    resolution: {integrity: sha512-TLtW70mERkhEtlgMmCq2mlZIVvjWvGq6Vw2+GmB4eOUAh3EClwMBJuY0AyCdhk1KmCUq8EYQDEltBgfQRcfTpQ==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.2.1:
-    resolution: {integrity: sha512-OOVnX+aM8xJ5zYBmpqzSVCX5KFU+wi1gSfbv9X+nXk1rLjicHGm5U847oDmYBF5iyxkJDQBMsW9sr+7X4g8Yhg==}
+  envio-linux-arm64@3.3.2:
+    resolution: {integrity: sha512-BEJr4lW0CQSUMljKFV+9cUXet0hXHYRiofdrB08S+3sp6JmEamxdv0gjXhVLXoxAkIs3mQX+qx8iBzUM/MgYFw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.2.1:
-    resolution: {integrity: sha512-/0lWrS/l2VYwdx7t0QvBE8b1R2vsnWpgi2q2xWqSmyOI9SOPU1q9YUElkhaDQFHEUXvqzyDDZPqxQacFtJggXw==}
+  envio-linux-x64-musl@3.3.2:
+    resolution: {integrity: sha512-aVZlD6Bxy2jE6d2PCYwVX2Aareyhssh0nWXRr4fv4qIYznDjEO1k0RMvVreyQC1TkKmjW8tVgDMnvkQ/mMLQIA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.2.1:
-    resolution: {integrity: sha512-YACCs+YdemYj4KBYOw/o6fi3hofAWrJ8VOeCwaOWEAzlqQxqkZ6h3O7puZWLnmjgdJvBAReUikFxI+E9MiyHOQ==}
+  envio-linux-x64@3.3.2:
+    resolution: {integrity: sha512-3/4QoogX4/KrazYh98Q/kp/JSuq/kWFAFqDsGVp9UvqKFV8oqMRY11PfTO+RWTEMhDl0t1f7qjAg9Bczmt4dCQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.2.1:
-    resolution: {integrity: sha512-mPvVeomNzi3pz7KqBEpfaiVM8JKZzNphAipT47KiTB+HUrvuMBGmqODgLYUJqQ+iJxiRuCqOVNDy8oCMsZjfwg==}
+  envio@3.3.2:
+    resolution: {integrity: sha512-v2zykvfLiizcdmehb+I0TVpah2RTzG4i7C3poIFERuqqOTIumOHVYNBsUenhm82Tv1xWY08+Fh0BodZXnWtndg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1199,6 +1153,10 @@ packages:
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   iconv-lite@0.4.24:
@@ -1454,14 +1412,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  ox@0.12.4:
-    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.14.29:
     resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
@@ -1520,10 +1470,6 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1549,8 +1495,8 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
   react-dom@19.2.6:
@@ -1569,6 +1515,10 @@ packages:
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   real-require@0.2.0:
@@ -1680,6 +1630,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -1725,9 +1679,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tdigest@0.1.2:
-    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
@@ -1800,16 +1751,16 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.46.2:
-    resolution: {integrity: sha512-w8Qv5Vyo7TfXcH3vgmxRa1NRvzJCDy2aSGSRsJn3503nC/qVbgEQ+n3aj/CkqWXbloudZh97h5o5aQrQSVGy0w==}
+  viem@2.53.1:
+    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  viem@2.53.1:
-    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
+  viem@2.54.0:
+    resolution: {integrity: sha512-DW6KW3m89+3MLozFNPuI9Nhz2hJw375hUo1bpbo3qXipBvjdjF26B/d3U5adVyLGKOfqK4XeA1wPDWQTFQ/ltA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -2268,33 +2219,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    optionalDependencies:
-      '@envio-dev/hyperfuel-client-darwin-arm64': 1.2.2
-      '@envio-dev/hyperfuel-client-darwin-x64': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-arm64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
-      '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -2433,7 +2357,8 @@ snapshots:
 
   '@nodable/entities@2.1.0': {}
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@oxc-project/types@0.133.0': {}
 
@@ -2443,6 +2368,11 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.6(react@19.2.5)
+
+  '@rescript/react@0.14.1(react-dom@19.2.6(react@19.2.7))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.6(react@19.2.7)
 
   '@rescript/runtime@12.2.0': {}
 
@@ -2666,22 +2596,20 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  bintrees@1.0.2: {}
-
   bn.js@5.2.3: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
       qs: 6.15.2
-      raw-body: 2.5.2
+      raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
@@ -2808,26 +2736,25 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.2.1:
+  envio-darwin-arm64@3.3.2:
     optional: true
 
-  envio-darwin-x64@3.2.1:
+  envio-darwin-x64@3.3.2:
     optional: true
 
-  envio-linux-arm64@3.2.1:
+  envio-linux-arm64@3.3.2:
     optional: true
 
-  envio-linux-x64-musl@3.2.1:
+  envio-linux-x64-musl@3.3.2:
     optional: true
 
-  envio-linux-x64@3.2.1:
+  envio-linux-x64@3.3.2:
     optional: true
 
-  envio@3.2.1(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+  envio@3.3.2(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
-      '@envio-dev/hyperfuel-client': 1.2.2
       '@fuel-ts/crypto': 0.103.0(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))
       '@fuel-ts/errors': 0.103.0
       '@fuel-ts/hasher': 0.103.0(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))
@@ -2847,18 +2774,63 @@ snapshots:
       pino: 10.3.1
       pino-pretty: 13.1.3
       postgres: 3.4.8
-      prom-client: 15.1.3
       react: 19.2.5
       rescript-schema: 9.5.1
       tsx: 4.21.0
-      viem: 2.46.2(typescript@6.0.3)(zod@3.25.76)
+      viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.2.1
-      envio-darwin-x64: 3.2.1
-      envio-linux-arm64: 3.2.1
-      envio-linux-x64: 3.2.1
-      envio-linux-x64-musl: 3.2.1
+      envio-darwin-arm64: 3.3.2
+      envio-darwin-x64: 3.3.2
+      envio-linux-arm64: 3.3.2
+      envio-linux-x64: 3.3.2
+      envio-linux-x64-musl: 3.3.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - react-devtools-core
+      - react-dom
+      - rescript
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vitest
+      - zod
+
+  envio@3.3.2(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+    dependencies:
+      '@clickhouse/client': 1.17.0
+      '@elastic/ecs-pino-format': 1.4.0
+      '@fuel-ts/crypto': 0.103.0(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))
+      '@fuel-ts/errors': 0.103.0
+      '@fuel-ts/hasher': 0.103.0(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))
+      '@fuel-ts/math': 0.103.0
+      '@fuel-ts/utils': 0.103.0(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))
+      '@rescript/react': 0.14.1(react-dom@19.2.6(react@19.2.7))(react@19.2.5)
+      '@rescript/runtime': 12.2.0
+      bignumber.js: 9.3.1
+      date-fns: 3.3.1
+      dotenv: 16.4.5
+      eventsource: 4.1.0
+      express: 4.20.0
+      ink: 6.8.0(react@19.2.5)
+      ink-big-text: 2.0.0(ink@6.8.0(react@19.2.5))(react@19.2.5)
+      ink-spinner: 5.0.0(ink@6.8.0(react@19.2.5))(react@19.2.5)
+      js-sdsl: 4.4.2
+      pino: 10.3.1
+      pino-pretty: 13.1.3
+      postgres: 3.4.8
+      react: 19.2.5
+      rescript-schema: 9.5.1
+      tsx: 4.21.0
+      viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
+      yargs: 17.7.2
+    optionalDependencies:
+      envio-darwin-arm64: 3.3.2
+      envio-darwin-x64: 3.3.2
+      envio-linux-arm64: 3.3.2
+      envio-linux-x64: 3.3.2
+      envio-linux-x64-musl: 3.3.2
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2940,7 +2912,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.0
@@ -3070,6 +3042,14 @@ snapshots:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
       toidentifier: 1.0.1
 
   iconv-lite@0.4.24:
@@ -3275,21 +3255,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  ox@0.12.4(typescript@6.0.3)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.29(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -3365,11 +3330,6 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.2
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3396,16 +3356,21 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@2.5.2:
+  raw-body@2.5.3:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
   react-dom@19.2.6(react@19.2.5):
     dependencies:
       react: 19.2.5
+      scheduler: 0.27.0
+
+  react-dom@19.2.6(react@19.2.7):
+    dependencies:
+      react: 19.2.7
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
@@ -3416,6 +3381,8 @@ snapshots:
       scheduler: 0.27.0
 
   react@19.2.5: {}
+
+  react@19.2.7: {}
 
   real-require@0.2.0: {}
 
@@ -3547,6 +3514,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   std-env@4.1.0: {}
 
   string-similarity@4.0.4: {}
@@ -3589,10 +3558,6 @@ snapshots:
       has-flag: 4.0.0
 
   tagged-tag@1.0.0: {}
-
-  tdigest@0.1.2:
-    dependencies:
-      bintrees: 1.0.2
 
   terminal-size@4.0.1: {}
 
@@ -3651,7 +3616,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.46.2(typescript@6.0.3)(zod@3.25.76):
+  viem@2.53.1(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -3659,7 +3624,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.12.4(typescript@6.0.3)(zod@3.25.76)
+      ox: 0.14.29(typescript@6.0.3)(zod@3.25.76)
       ws: 8.21.0
     optionalDependencies:
       typescript: 6.0.3
@@ -3668,7 +3633,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.53.1(typescript@6.0.3)(zod@3.25.76):
+  viem@2.54.0(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,15 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  # Explicitly approved while Envio 3.3.2 and its platform binaries are under
+  # the registry's `next` tag.
+  - "envio@3.3.2"
+  - "envio-darwin-arm64@3.3.2"
+  - "envio-darwin-x64@3.3.2"
+  - "envio-linux-arm64@3.3.2"
+  - "envio-linux-x64@3.3.2"
+  - "envio-linux-x64-musl@3.3.2"
 allowBuilds:
   "es5-ext@0.10.63": true
   # esbuild ships native binaries it builds on install; required because
@@ -76,7 +85,7 @@ overrides:
   # Envio bundles express + ws; patches the transitive advisories CI's
   # audit gate flagged at moderate+. Pinned to ranges known to address
   # each CVE without churning unrelated majors.
-  "body-parser@<1.20.3": "1.20.3"
+  "body-parser@<1.20.6": "1.20.6"
   "cookie@<0.7.0": "0.7.0"
   "express@<4.20.0": "4.20.0"
   "path-to-regexp@<0.1.13": "0.1.13"


### PR DESCRIPTION
## Summary

Provider-side JSON-RPC internal errors no longer crash snapshot collection on the first failure; they now use the existing bounded retry and backoff path, while genuine invalid-input responses still fail immediately. This covers the production Arbitrum native-balance failure where a valid Multicall3 `getEthBalance` request received a transient `Internal error`; replaying the same request succeeded, indicating provider instability rather than malformed calldata. RPC error classification also safely ignores non-numeric `code` and `status` metadata instead of risking a secondary coercion error.

Envio is upgraded from 3.2.1 to 3.3.2 with explicit release-age exceptions for its approved `next`-tag platform binaries. Envio 3.3.2 now enforces identical event options across handlers and contract registrations, so the Kodiak LP `Transfer` registrations share the same treasury filter. The low-severity `body-parser` size-limit advisory is also remediated at 1.20.6, leaving the dependency audit clean.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm codegen`
- `pnpm validate` (all lint, typecheck, build, and test suites passed; 138 indexer tests passed)
- `pnpm audit --audit-level low --json` (0 vulnerabilities)
- Full local Docker Compose runtime with Postgres, Hasura, and Envio 3.3.2: the indexer resumed its checkpoint and processed blocks across Polygon, Fantom, Arbitrum, and Berachain
- CodeRabbit local review against `master` (valid RPC metadata finding fixed; follow-up test-structure finding verified as a false positive against the source and passing suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic retry behavior for transient JSON-RPC “internal error” failures while continuing to stop on genuine invalid input errors.
  * Tightened indexing for Kodiak LP `Transfer` events so only relevant logs trigger UniV3 pool registration.
* **Tests**
  * Expanded retry tests to cover additional “internal error” shapes, wrapped error causes, and ensured non-retryable invalid input errors fail fast.
  * Confirmed RPC error metadata that isn’t numeric is preserved.
* **Chores**
  * Updated the `envio` dependency and adjusted workspace release and patching rules (including `body-parser`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
