### PR TITLE
fix(security): remediate PostCSS and image vulnerabilities

### DIFF
--- a/Dockerfile-hasura
+++ b/Dockerfile-hasura
@@ -9,13 +9,23 @@ RUN DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get update \
     gzip \
     libblkid1 \
     libcap2 \
+    libc-bin \
+    libc6 \
     libcurl4 \
     libexpat1 \
     libgcc-s1 \
     libgcrypt20 \
+    libgssapi-krb5-2 \
     libgnutls30 \
+    libk5crypto3 \
+    libkrb5-3 \
+    libkrb5support0 \
     libmount1 \
     libnghttp2-14 \
+    libpam-modules \
+    libpam-modules-bin \
+    libpam-runtime \
+    libpam0g \
     libperl5.34 \
     libpq5 \
     libpython3.10-minimal \

--- a/Dockerfile-indexer
+++ b/Dockerfile-indexer
@@ -41,6 +41,8 @@ RUN chown -R node:node apps/indexer/.envio
 
 ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+WORKDIR /app/apps/indexer
+
 USER node
 
-CMD ["tsx", "apps/indexer/src/start-envio.ts", "start"]
+CMD ["tsx", "src/start-envio.ts", "start"]

--- a/Dockerfile-indexer
+++ b/Dockerfile-indexer
@@ -33,9 +33,14 @@ RUN pnpm install --frozen-lockfile \
 COPY . .
 RUN pnpm --dir apps/indexer codegen \
   && pnpm run build \
-  && rm -rf /app/.pnpm-store /pnpm/store /root/.cache/pnpm /usr/local/bin/npm /usr/local/bin/npx /usr/local/lib/node_modules/npm
+  && rm -rf /app/.pnpm-store /corepack /pnpm /root/.cache/pnpm \
+    /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx \
+    /usr/local/bin/pnpm /usr/local/bin/pnpx \
+    /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm
 RUN chown -R node:node apps/indexer/.envio
+
+ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 USER node
 
-CMD ["pnpm", "--dir", "apps/indexer", "envio:start"]
+CMD ["tsx", "apps/indexer/src/start-envio.ts", "start"]

--- a/Dockerfile-metrics-api
+++ b/Dockerfile-metrics-api
@@ -33,9 +33,15 @@ RUN pnpm install --frozen-lockfile \
 COPY . .
 RUN pnpm --dir apps/indexer codegen \
   && pnpm run build \
-  && rm -rf /app/.pnpm-store /pnpm/store /root/.cache/pnpm /usr/local/bin/npm /usr/local/bin/npx /usr/local/lib/node_modules/npm apps/indexer/.envio
+  && rm -rf /app/.pnpm-store /corepack /pnpm /root/.cache/pnpm \
+    /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx \
+    /usr/local/bin/pnpm /usr/local/bin/pnpx \
+    /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm \
+    apps/indexer/.envio
+
+ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 USER node
 
 EXPOSE 3000
-CMD ["pnpm", "--dir", "apps/metrics-api", "start"]
+CMD ["tsx", "apps/metrics-api/src/cli.ts"]

--- a/Dockerfile-metrics-api
+++ b/Dockerfile-metrics-api
@@ -41,7 +41,9 @@ RUN pnpm --dir apps/indexer codegen \
 
 ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+WORKDIR /app/apps/metrics-api
+
 USER node
 
 EXPOSE 3000
-CMD ["tsx", "apps/metrics-api/src/cli.ts"]
+CMD ["tsx", "src/cli.ts"]

--- a/Dockerfile-metrics-publisher
+++ b/Dockerfile-metrics-publisher
@@ -33,8 +33,14 @@ RUN pnpm install --frozen-lockfile \
 COPY . .
 RUN pnpm --dir apps/indexer codegen \
   && pnpm run build \
-  && rm -rf /app/.pnpm-store /pnpm/store /root/.cache/pnpm /usr/local/bin/npm /usr/local/bin/npx /usr/local/lib/node_modules/npm apps/indexer/.envio
+  && rm -rf /app/.pnpm-store /corepack /pnpm /root/.cache/pnpm \
+    /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx \
+    /usr/local/bin/pnpm /usr/local/bin/pnpx \
+    /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm \
+    apps/indexer/.envio
+
+ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 USER node
 
-CMD ["pnpm", "--dir", "apps/metrics-publisher", "start"]
+CMD ["tsx", "apps/metrics-publisher/src/cli.ts"]

--- a/Dockerfile-metrics-publisher
+++ b/Dockerfile-metrics-publisher
@@ -41,6 +41,8 @@ RUN pnpm --dir apps/indexer codegen \
 
 ENV PATH=/app/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+WORKDIR /app/apps/metrics-publisher
+
 USER node
 
-CMD ["tsx", "apps/metrics-publisher/src/cli.ts"]
+CMD ["tsx", "src/cli.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ overrides:
   qs@<6.15.2: 6.15.2
   send@<0.19.0: 0.19.0
   serve-static@<1.16.0: 1.16.0
+  postcss@<=8.5.17: 8.5.22
   ws@>=8.0.0 <8.21.0: 8.21.0
   vite@>=8.0.0 <8.0.16: 8.0.16
   esbuild@>=0.17.0 <0.28.1: 0.28.1
@@ -1377,8 +1378,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1459,8 +1460,8 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.8:
@@ -3231,7 +3232,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   negotiator@0.6.3: {}
 
@@ -3320,9 +3321,9 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
 
-  postcss@8.5.15:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3654,7 +3655,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.22
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,6 @@ minimumReleaseAgeExclude:
   - "envio-linux-x64@3.3.2"
   - "envio-linux-x64-musl@3.3.2"
 allowBuilds:
-  "es5-ext@0.10.63": true
   # esbuild ships native binaries it builds on install; required because
   # vitest (our test runner) depends on it transitively. Without this entry,
   # `strictDepBuilds: true` rejects the install with ERR_PNPM_IGNORED_BUILDS.
@@ -92,6 +91,9 @@ overrides:
   "qs@<6.15.2": "6.15.2"
   "send@<0.19.0": "0.19.0"
   "serve-static@<1.16.0": "1.16.0"
+  # postcss GHSA-r28c-9q8g-f849 (high, arbitrary source-map disclosure),
+  # fixed in 8.5.18. Use the newest patched release past the 7-day cutoff.
+  "postcss@<=8.5.17": "8.5.22"
   # ws GHSA-96hv-2xvq-fx4p (high, memory-exhaustion DoS from tiny fragments),
   # fixed in 8.21.0. Pulled transitively via envio>ink>ws. The prior cap of
   # 8.20.1 predates this advisory and is still vulnerable; bumped to 8.21.0

--- a/tests/railway/config.test.ts
+++ b/tests/railway/config.test.ts
@@ -171,18 +171,19 @@ describe("Railway config-as-code", () => {
     expect(readFileSync("Dockerfile-hasura", "utf8")).toContain("--only-upgrade");
     expect(readFileSync("Dockerfile-hasura", "utf8")).not.toContain("apt-get upgrade");
     const indexerDockerfile = readFileSync("Dockerfile-indexer", "utf8");
-    expect(indexerDockerfile).toContain('CMD ["tsx", "apps/indexer/src/start-envio.ts", "start"]');
+    expect(indexerDockerfile).toContain("WORKDIR /app/apps/indexer");
+    expect(indexerDockerfile).toContain('CMD ["tsx", "src/start-envio.ts", "start"]');
     expect(indexerDockerfile).toContain("chown -R node:node apps/indexer/.envio");
     const metricsApiDockerfile = readFileSync("Dockerfile-metrics-api", "utf8");
     const metricsPublisherDockerfile = readFileSync("Dockerfile-metrics-publisher", "utf8");
     expect(metricsApiDockerfile).toContain("pnpm --dir apps/indexer codegen");
     expect(metricsApiDockerfile).toContain("apps/indexer/.envio");
-    expect(metricsApiDockerfile).toContain('CMD ["tsx", "apps/metrics-api/src/cli.ts"]');
+    expect(metricsApiDockerfile).toContain("WORKDIR /app/apps/metrics-api");
+    expect(metricsApiDockerfile).toContain('CMD ["tsx", "src/cli.ts"]');
     expect(metricsPublisherDockerfile).toContain("pnpm --dir apps/indexer codegen");
     expect(metricsPublisherDockerfile).toContain("apps/indexer/.envio");
-    expect(metricsPublisherDockerfile).toContain(
-      'CMD ["tsx", "apps/metrics-publisher/src/cli.ts"]',
-    );
+    expect(metricsPublisherDockerfile).toContain("WORKDIR /app/apps/metrics-publisher");
+    expect(metricsPublisherDockerfile).toContain('CMD ["tsx", "src/cli.ts"]');
   });
 
   test("fails Hasura early when required Railway env variables are missing", () => {

--- a/tests/railway/config.test.ts
+++ b/tests/railway/config.test.ts
@@ -161,25 +161,28 @@ describe("Railway config-as-code", () => {
       expect(content).not.toContain("pnpm prune --prod");
       expect(content).toContain("/pnpm/store");
       expect(content).toContain("/root/.cache/pnpm");
+      expect(content).toContain("/usr/local/lib/node_modules/corepack");
       expect(content).toContain("/usr/local/lib/node_modules/npm");
+      expect(content).toContain("ENV PATH=/app/node_modules/.bin:");
       expect(content).not.toContain('node", "--version');
       expect(content).toContain("USER node");
     }
 
     expect(readFileSync("Dockerfile-hasura", "utf8")).toContain("--only-upgrade");
     expect(readFileSync("Dockerfile-hasura", "utf8")).not.toContain("apt-get upgrade");
-    expect(readFileSync("Dockerfile-indexer", "utf8")).toContain("envio:start");
-    expect(readFileSync("Dockerfile-indexer", "utf8")).toContain(
-      "chown -R node:node apps/indexer/.envio",
-    );
+    const indexerDockerfile = readFileSync("Dockerfile-indexer", "utf8");
+    expect(indexerDockerfile).toContain('CMD ["tsx", "apps/indexer/src/start-envio.ts", "start"]');
+    expect(indexerDockerfile).toContain("chown -R node:node apps/indexer/.envio");
     const metricsApiDockerfile = readFileSync("Dockerfile-metrics-api", "utf8");
     const metricsPublisherDockerfile = readFileSync("Dockerfile-metrics-publisher", "utf8");
     expect(metricsApiDockerfile).toContain("pnpm --dir apps/indexer codegen");
     expect(metricsApiDockerfile).toContain("apps/indexer/.envio");
-    expect(metricsApiDockerfile).toContain("apps/metrics-api");
+    expect(metricsApiDockerfile).toContain('CMD ["tsx", "apps/metrics-api/src/cli.ts"]');
     expect(metricsPublisherDockerfile).toContain("pnpm --dir apps/indexer codegen");
     expect(metricsPublisherDockerfile).toContain("apps/indexer/.envio");
-    expect(metricsPublisherDockerfile).toContain("apps/metrics-publisher");
+    expect(metricsPublisherDockerfile).toContain(
+      'CMD ["tsx", "apps/metrics-publisher/src/cli.ts"]',
+    );
   });
 
   test("fails Hasura early when required Railway env variables are missing", () => {


### PR DESCRIPTION
## Summary

Remediates the PostCSS source-map disclosure advisory and removes vulnerable package-manager tooling from the production Node images. The Hasura image also upgrades the remaining fixable Ubuntu packages, while runtime entrypoints invoke the installed application binaries directly.

## Validation

- Clean unfrozen and frozen pnpm installs passed on Node 24.14.1 with pnpm 11.13.0.
- `pnpm run validate` passed: build, Biome, typecheck, and 221 tests passed with 3 expected skips.
- `pnpm audit --audit-level moderate` reports no known vulnerabilities.
- All four Docker images built with Docker Desktop; runtime smoke checks passed.
- Trivy 0.69.3 reported zero configuration and image vulnerabilities for the validated images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added required system, Kerberos, and PAM runtime libraries.
  * Patched vulnerable PostCSS versions.

* **Performance & Reliability**
  * Reduced container image contents by removing build-only tools, caches, and development data.
  * Simplified service startup for more predictable runtime behavior.

* **Tests**
  * Expanded container validation to verify runtime configuration and startup commands across services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->