### PR TITLE
fix(deps): patch postcss and nanoid advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,8 @@ overrides:
   qs@<6.15.2: 6.15.2
   send@<0.19.0: 0.19.0
   serve-static@<1.16.0: 1.16.0
-  postcss@<=8.5.17: 8.5.22
+  postcss@<8.5.23: 8.5.23
+  nanoid@>=3.0.0 <3.3.17: 3.3.17
   ws@>=8.0.0 <8.21.0: 8.21.0
   vite@>=8.0.0 <8.0.16: 8.0.16
   esbuild@>=0.17.0 <0.28.1: 0.28.1
@@ -1378,8 +1379,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1460,8 +1461,8 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.8:
@@ -3232,7 +3233,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   negotiator@0.6.3: {}
 
@@ -3321,9 +3322,9 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
 
-  postcss@8.5.22:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3655,7 +3656,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.22
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,8 +92,12 @@ overrides:
   "send@<0.19.0": "0.19.0"
   "serve-static@<1.16.0": "1.16.0"
   # postcss GHSA-r28c-9q8g-f849 (high, arbitrary source-map disclosure),
-  # fixed in 8.5.18. Use the newest patched release past the 7-day cutoff.
-  "postcss@<=8.5.17": "8.5.22"
+  # fixed in 8.5.18, plus the current incomplete-fix advisory fixed in
+  # 8.5.23. Use the newest patched release past the 7-day cutoff.
+  "postcss@<8.5.23": "8.5.23"
+  # nanoid GHSA-mwcw-c2jj-8g6p (moderate, zero-size custom generator loop),
+  # fixed in 3.3.17. Scope this to the vulnerable 3.x range.
+  "nanoid@>=3.0.0 <3.3.17": "3.3.17"
   # ws GHSA-96hv-2xvq-fx4p (high, memory-exhaustion DoS from tiny fragments),
   # fixed in 8.21.0. Pulled transitively via envio>ink>ws. The prior cap of
   # 8.20.1 predates this advisory and is still vulnerable; bumped to 8.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ overrides:
   # fixed in 8.5.18, plus the current incomplete-fix advisory fixed in
   # 8.5.23. Use the newest patched release past the 7-day cutoff.
   "postcss@<8.5.23": "8.5.23"
-  # nanoid GHSA-mwcw-c2jj-8g6p (moderate, zero-size custom generator loop),
+  # nanoid GHSA-2v37-7h3g-55p8 (moderate, zero-size custom generator loop),
   # fixed in 3.3.17. Scope this to the vulnerable 3.x range.
   "nanoid@>=3.0.0 <3.3.17": "3.3.17"
   # ws GHSA-96hv-2xvq-fx4p (high, memory-exhaustion DoS from tiny fragments),


### PR DESCRIPTION
## Summary
- Patch PostCSS to 8.5.23 for the incomplete-fix advisory.
- Patch nanoid 3.x to 3.3.17.
- Regenerate `pnpm-lock.yaml` with range-scoped overrides.

## Validation
- Frozen dependency install completed.
- Final moderate-level audit passed.
- Biome check, format check, lint, and diff checks passed.
- Follow-up Envio codegen and build verification passed in a clean checkout.
- The original worker run also reported a test-environment write error (`Unknown system error -122: write`); no test source changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security protections for PostCSS to the latest patched version.
  * Added safeguards to ensure affected Nanoid 3.x versions use a patched release.
  * Improved application security without changing user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->