### PR TITLE
fix(deps): remediate nanoid advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ overrides:
   send@<0.19.0: 0.19.0
   serve-static@<1.16.0: 1.16.0
   postcss@<8.5.23: 8.5.23
-  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
   ws@>=8.0.0 <8.21.0: 8.21.0
   vite@>=8.0.0 <8.0.16: 8.0.16
   esbuild@>=0.17.0 <0.28.1: 0.28.1
@@ -1379,8 +1379,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3233,7 +3233,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -3324,7 +3324,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,9 +95,9 @@ overrides:
   # fixed in 8.5.18, plus the current incomplete-fix advisory fixed in
   # 8.5.23. Use the newest patched release past the 7-day cutoff.
   "postcss@<8.5.23": "8.5.23"
-  # nanoid GHSA-2v37-7h3g-55p8 (moderate, zero-size custom generator loop),
-  # fixed in 3.3.17. Scope this to the vulnerable 3.x range.
-  "nanoid@>=3.0.0 <3.3.17": "3.3.17"
+  # nanoid GHSA-2v37-7h3g-55p8 (high, zero-size custom generator loop),
+  # fixed in 3.3.18. Scope this to the vulnerable 3.x range.
+  "nanoid@>=3.0.0 <3.3.18": "3.3.18"
   # ws GHSA-96hv-2xvq-fx4p (high, memory-exhaustion DoS from tiny fragments),
   # fixed in 8.21.0. Pulled transitively via envio>ink>ws. The prior cap of
   # 8.20.1 predates this advisory and is still vulnerable; bumped to 8.21.0


### PR DESCRIPTION
## Summary

- Remediate the high-severity `nanoid` advisory `GHSA-2v37-7h3g-55p8`.
- Raise the existing range-scoped `nanoid` override from `3.3.17` to `3.3.18`.
- Refresh the lockfile without changing application dependencies or weakening pnpm policy.

## Advisory

`nanoid` versions `<3.3.18` can loop indefinitely when a custom generator is called with a zero size. The vulnerable package is transitive through the Vitest/Vite/PostCSS toolchain and Envio-related workspace paths.

## Changes

- `pnpm-workspace.yaml`: target `nanoid@>=3.0.0 <3.3.18` with `3.3.18`.
- `pnpm-lock.yaml`: resolve the affected package and PostCSS dependency to `nanoid@3.3.18`.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts` — passed
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `pnpm run check` — passed
- `pnpm run build` — passed
- `pnpm test` — passed: 207 tests, 3 skipped
- `git diff --check` — passed

The repository's `minimumReleaseAge`, `engineStrict`, `blockExoticSubdeps`, and build-script policy were preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security handling for `nanoid` to address a high-severity advisory.
  * Ensured vulnerable 3.x versions are upgraded to version 3.3.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->