### PR TITLE
Hold published bounds during a reindex, and upgrade envio to 3.6.1

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.3.2",
+    "envio": "3.6.1",
     "viem": "2.53.1"
   },
   "devDependencies": {

--- a/apps/metrics-publisher/src/publisher.ts
+++ b/apps/metrics-publisher/src/publisher.ts
@@ -48,7 +48,7 @@ export type PublishResult = {
   manifestPublishedLast: boolean;
   range?: DateRange;
   skipped: boolean;
-  skipReason?: "lock_held" | "not_data_ready";
+  skipReason?: "lock_held" | "not_data_ready" | "reindex_in_progress";
   runId: string;
   writtenKeys: string[];
 };
@@ -215,6 +215,18 @@ export async function publishMetricsArtifacts(input: {
         indexingProgress,
         skipped: true,
         skipReason: "not_data_ready",
+        runId: lock.runId,
+        writtenKeys: [],
+      };
+    }
+    if (isBehindPublishedBounds(bounds.latestDate, existingManifest)) {
+      return {
+        manifestPublishedLast: false,
+        deletedKeys: [],
+        deploymentId,
+        indexingProgress,
+        skipped: true,
+        skipReason: "reindex_in_progress",
         runId: lock.runId,
         writtenKeys: [],
       };
@@ -495,6 +507,13 @@ function hasMissingDailyMetrics(range: DateRange, metrics: Array<{ date: string 
     cursor += DAY_MS;
   }
   return false;
+}
+
+function isBehindPublishedBounds(
+  latestDate: string,
+  existingManifest: Manifest | undefined,
+): boolean {
+  return existingManifest !== undefined && latestDate < existingManifest.latestDate;
 }
 
 function isFreshForDeploymentHandover(latestDate: string, now: Date): boolean {

--- a/apps/metrics-publisher/tests/publisher.test.ts
+++ b/apps/metrics-publisher/tests/publisher.test.ts
@@ -626,6 +626,39 @@ describe("metrics publisher", () => {
     await expect(store.getJson("v2/publisher.lock")).rejects.toThrow("Artifact not found");
   });
 
+  test("skips when the indexer has been reset and reports bounds behind the published manifest", async () => {
+    const store = new MemoryArtifactStore();
+    await store.putJson("v2/manifest.json", existingCurrentDeploymentManifest);
+
+    const result = await publishMetricsArtifacts({
+      deploymentId: "current-indexer",
+      source: source({
+        fetchBounds: async () => ({ earliestDate: "2022-05-01", latestDate: "2023-02-09" }),
+        fetchDailyMetrics: async () => {
+          throw new Error("should not fetch daily metrics while the indexer is reindexing");
+        },
+        fetchTreasuryAssets: async () => {
+          throw new Error("should not fetch treasury assets while the indexer is reindexing");
+        },
+        fetchOhmSupply: async () => {
+          throw new Error("should not fetch OHM supply while the indexer is reindexing");
+        },
+      }),
+      store,
+      now: () => new Date("2026-06-01T08:15:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      deletedKeys: [],
+      skipped: true,
+      skipReason: "reindex_in_progress",
+      manifestPublishedLast: false,
+      writtenKeys: [],
+    });
+    expect(store.json<Manifest>("v2/manifest.json")).toEqual(existingCurrentDeploymentManifest);
+    await expect(store.getJson("v2/publisher.lock")).rejects.toThrow("Artifact not found");
+  });
+
   test("incremental publish for the same deployment can use cross-chain complete bounds", async () => {
     const store = new MemoryArtifactStore();
     const observedCompleteness: PublishBoundsCompleteness[] = [];

--- a/docs/railway-metrics-api.md
+++ b/docs/railway-metrics-api.md
@@ -152,7 +152,8 @@ for event ingestion.
 Railway deployment flow:
 
 1. A new indexer deployment starts with `envio start -r` against Envio's default
-   schema.
+   schema. Any restart of the indexer container does the same, including
+   platform-initiated restarts that keep the current deployment.
 2. Existing metric artifacts remain in the bucket, and `metrics-api` continues
    serving the currently published manifest while the indexer reindexes.
 3. The publisher cron reads Hasura but skips cleanly with
@@ -249,6 +250,12 @@ The first publish for a deployment also requires that latest all-chain date to
 be within one day of the publisher's current UTC date. This prevents a new
 indexer deployment from taking over the manifest while it is still several days
 behind the existing published snapshots.
+Published bounds never move backwards. If Hasura reports a latest date earlier
+than the published manifest's `latestDate`, the publisher exits successfully
+with `skipReason: "reindex_in_progress"` and leaves the manifest untouched. That
+covers a reindex triggered by an indexer restart on the same deployment id,
+where the freshness gate above does not apply because the deployment already has
+published artifacts.
 The manifest is published last, so partial shard uploads are not exposed through
 `/v2/bounds`.
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.3.2",
+    "envio": "3.6.1",
     "tsx": "4.22.4",
     "viem": "2.53.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.3.2
-        version: 3.3.2(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.6.1
+        version: 3.6.1(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -94,8 +94,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.3.2
-        version: 3.3.2(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.6.1
+        version: 3.6.1(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       viem:
         specifier: 2.53.1
         version: 2.53.1(typescript@6.0.3)(zod@3.25.76)
@@ -963,36 +963,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.3.2:
-    resolution: {integrity: sha512-mJp85CHkAudLMyOBXXQ/XVOtzsG4YpyYDa2QO9jH4hCpiCRWrYcgtt4/c6rfjqH4fHhN69iQMp3wZDXV3ldwEA==}
+  envio-darwin-arm64@3.6.1:
+    resolution: {integrity: sha512-ecGuGkptoCbfH5ULq4yAhRRB8pAK8pzQp6JahmBsH7dYSOmgM8xQRqgS5QwVgjrfQWl5GH3S4dyZpnSsCNcy+w==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.3.2:
-    resolution: {integrity: sha512-TLtW70mERkhEtlgMmCq2mlZIVvjWvGq6Vw2+GmB4eOUAh3EClwMBJuY0AyCdhk1KmCUq8EYQDEltBgfQRcfTpQ==}
+  envio-darwin-x64@3.6.1:
+    resolution: {integrity: sha512-zADvYOhv8Yjsp4a5AooJg4kRPKcidyjljru8XpUIIvLq5VdHQcs/5r1EnhDwPgA2Y9gBqTNCWZJ80pQs6Vg/0g==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.3.2:
-    resolution: {integrity: sha512-BEJr4lW0CQSUMljKFV+9cUXet0hXHYRiofdrB08S+3sp6JmEamxdv0gjXhVLXoxAkIs3mQX+qx8iBzUM/MgYFw==}
+  envio-linux-arm64@3.6.1:
+    resolution: {integrity: sha512-dTbMq6BtAn0tEduGHdunyomIVNVTx32pr7tzRDdJ/rlPQxdNDkKboPIFeuxMoTiLKtUIyrkDRb/KZUNna72suQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.3.2:
-    resolution: {integrity: sha512-aVZlD6Bxy2jE6d2PCYwVX2Aareyhssh0nWXRr4fv4qIYznDjEO1k0RMvVreyQC1TkKmjW8tVgDMnvkQ/mMLQIA==}
+  envio-linux-x64-musl@3.6.1:
+    resolution: {integrity: sha512-APwQYvKhzMEsrWsKAhjx2+p8kqJi00Oz46YyW7Ln005pt96Am6ACqC7pWoo5J5Zuui8Y2lR4wJmEWKZeH9pkRQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.3.2:
-    resolution: {integrity: sha512-3/4QoogX4/KrazYh98Q/kp/JSuq/kWFAFqDsGVp9UvqKFV8oqMRY11PfTO+RWTEMhDl0t1f7qjAg9Bczmt4dCQ==}
+  envio-linux-x64@3.6.1:
+    resolution: {integrity: sha512-eynhAQXaEimq/QT0REEXPqjAs3J7rURymL7PRSXBvrfQVUUKjiO4l5S9jL5jlSpWpZR4o2xcW6xZAuk7O1B9sw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.3.2:
-    resolution: {integrity: sha512-v2zykvfLiizcdmehb+I0TVpah2RTzG4i7C3poIFERuqqOTIumOHVYNBsUenhm82Tv1xWY08+Fh0BodZXnWtndg==}
+  envio@3.6.1:
+    resolution: {integrity: sha512-n8N3ih7rEL6saDTXPOI1sxwruaD4HfJBtNnrlrmDDzv9Ccj8IFElBQJc+JvSIfT8TwzVZynPiHiL6e/gvtc7fg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2738,22 +2738,22 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.3.2:
+  envio-darwin-arm64@3.6.1:
     optional: true
 
-  envio-darwin-x64@3.3.2:
+  envio-darwin-x64@3.6.1:
     optional: true
 
-  envio-linux-arm64@3.3.2:
+  envio-linux-arm64@3.6.1:
     optional: true
 
-  envio-linux-x64-musl@3.3.2:
+  envio-linux-x64-musl@3.6.1:
     optional: true
 
-  envio-linux-x64@3.3.2:
+  envio-linux-x64@3.6.1:
     optional: true
 
-  envio@3.3.2(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+  envio@3.6.1(react-dom@19.2.6(react@19.2.5))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2782,11 +2782,11 @@ snapshots:
       viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.3.2
-      envio-darwin-x64: 3.3.2
-      envio-linux-arm64: 3.3.2
-      envio-linux-x64: 3.3.2
-      envio-linux-x64-musl: 3.3.2
+      envio-darwin-arm64: 3.6.1
+      envio-darwin-x64: 3.6.1
+      envio-linux-arm64: 3.6.1
+      envio-linux-x64: 3.6.1
+      envio-linux-x64-musl: 3.6.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2799,7 +2799,7 @@ snapshots:
       - vitest
       - zod
 
-  envio@3.3.2(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+  envio@3.6.1(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2828,11 +2828,11 @@ snapshots:
       viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.3.2
-      envio-darwin-x64: 3.3.2
-      envio-linux-arm64: 3.3.2
-      envio-linux-x64: 3.3.2
-      envio-linux-x64-musl: 3.3.2
+      envio-darwin-arm64: 3.6.1
+      envio-darwin-x64: 3.6.1
+      envio-linux-arm64: 3.6.1
+      envio-linux-x64: 3.6.1
+      envio-linux-x64-musl: 3.6.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,15 +5,6 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  # Explicitly approved while Envio 3.3.2 and its platform binaries are under
-  # the registry's `next` tag.
-  - "envio@3.3.2"
-  - "envio-darwin-arm64@3.3.2"
-  - "envio-darwin-x64@3.3.2"
-  - "envio-linux-arm64@3.3.2"
-  - "envio-linux-x64@3.3.2"
-  - "envio-linux-x64-musl@3.3.2"
 allowBuilds:
   # esbuild ships native binaries it builds on install; required because
   # vitest (our test runner) depends on it transitively. Without this entry,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -145,3 +145,15 @@ If those match but disagree with the actual on-chain `balanceOf`, the token is n
 **Fix in this codebase:** `TokenDefinition.nonStandardBalance: true` routes snapshot balance reads through `readErc20BalanceOf` (cached `createEffect`, one RPC per (chain, token, wallet, block)) instead of the `TokenBalance` ledger. Set on every confirmed-broken token in `src/snapshot/chains/*`. Bounded cost: ~6 chains × ~10 wallets × ~10 non-standard tokens × 3 snapshots/day ≈ 1.8k RPC calls/day across all chains.
 
 **Where to apply (preventatively):** any ERC4626 vault, any WETH9-style wrapper, any rebasing receipt token, any bridge-minted token where you can't trace the mint path to a standard `_mint`. When in doubt, flag it — the cost of a cached `balanceOf` call is trivial; the cost of a negative-balance contamination is days of debugging and a 5× wrong treasury rollup.
+
+---
+
+## 2026-08-24 — A failing PR-environment deploy is not proof of a code defect
+
+**Pattern that bit us:** PR #355's `metrics-publisher` check failed with `Hasura GraphQL error: field 'chainValues' not found in type: 'GlobalMetricSnapshot'`. The PR bumped envio 3.3.2 → 3.6.1, and inspection lined up perfectly: production (3.3.2) had 27 fields on that type with `chainValues` and `supplyCategories` present, the PR environment (3.6.1) had 23 and a metadata export showing zero array *and* zero object relationships across every table. Envio's `sendOperation` swallows Hasura failures into a warning, and no warning appeared in the logs. The obvious read was that 3.6.1 had stopped creating `@derivedFrom` relationships, and I recommended dropping the upgrade on that basis.
+
+**It was wrong.** Standing the compose stack up locally on 3.6.1 created all four relationships — on a fresh start, across a restart, and across an `envio start -r` reset. Hasura in the PR environment also accepted the exact `pg_create_array_relationship` call when issued by hand. Simply redeploying the PR environment's indexer, same commit and same version, created all four. The original failure was a transient error during one startup, and the warning that would have revealed it was almost certainly eaten by Railway's 500 logs/sec replica limit, which was actively dropping batches of up to 780 messages from that service.
+
+**Why it's a trap:** a version bump in the diff supplies a ready-made culprit, and one environment's symptom looks like proof when it lines up that cleanly. Comparing two environments only shows they *differ*; it never shows *why*. The missing step was reproducing against the suspect version in isolation before assigning blame.
+
+**Where to apply:** any dependency upgrade whose failure surfaces only in a deployed environment. Reproduce locally against the new version first. If it behaves correctly there, suspect the environment and redeploy before touching the diff. Note also that `tsc` and the four test suites all pass against a broken Hasura surface — the publisher's queries are raw strings against a live endpoint, so nothing in CI covers that contract.


### PR DESCRIPTION
> **Update 2026-08-24.** Five of six chains have been frozen at the head since 2026-08-19 17:16:23 UTC and `/v2/bounds` has served `2026-08-19` for five days. That's the bug Change 2 fixes, so this went from precautionary to the reason to merge. See Change 2 and Sequencing.

The treasury and protocol pages on app.olympusdao.finance went blank this morning. `/v2/bounds` `latestDate` dropped from 2026-08-18 to 2024-06-06, so the frontend asked for recent dates and the API said it had nothing that new.

## What happened

At 11:26:02 UTC the indexer crashed writing a batch to Postgres:

```
ERROR: Failed writing batch to the database
  PostgresError 23505: duplicate key value violates unique constraint "envio_checkpoints_pkey"
  detail: "Key (id)=(40083918) already exists."
  schema: public   table: envio_checkpoints
```

`envio_checkpoints` is Envio's internal reorg bookkeeping, not one of ours. Nothing in our schema, handlers, or config references checkpoints, and the ids come from an in-memory counter in Envio's `IndexerState` seeded from `MAX(id)` at startup. All 6 chains share that one counter and run concurrently. Across every retained log line since the 08-17 deploy there is exactly one constraint violation, this one, and none on any of our tables.

The process exited and the container came back four seconds later:

```
[11:26:06] INFO: Initializing the indexer storage...
[11:26:15] INFO: The indexer storage is ready. Starting indexing!
```

`resolveEnvioArgs` in `apps/indexer/src/start-envio.ts` appends `-r` on any Railway start, so that restart dropped the Envio tables and began re-indexing from 2022. This was not a deploy. The current indexer deployment is still 8881f0c4 from 2026-08-17. No OOM, no SIGTERM.

Reset-on-start is intentional and documented, and a reindex is supposed to be invisible to clients because the published artifacts keep serving.

## Why it wasn't invisible

`isFreshForDeploymentHandover` only runs when `hasPublishedDeploymentArtifacts` is false, meaning it only guards a reset that arrives with a new deployment id. A crash and restart keeps the same commit SHA, so the gate was bypassed. The 13:15 UTC run published a 2023-01 to 2023-02 range and `minDate(..., bounds.latestDate)` pulled the manifest latestDate down to the backfill position. That is the moment the app went blank.

## Change 1: hold published bounds during a reindex

Adds `isBehindPublishedBounds`. If Hasura reports a latest date earlier than the published manifest's, the run exits successfully with `skipReason: "reindex_in_progress"` and leaves the manifest alone. Published bounds only ever move forward now.

A new test reproduces the incident: published manifest at 2026-05-30, bounds come back at 2023-02-09. It fails on the old code by fetching and republishing, and passes with the guard.

## Change 2: envio 3.3.2 to 3.6.1

**This is now the change that matters.** It was precautionary when I opened this PR. Five chains froze at the head about two hours later and haven't moved since.

Sampling `chain_metadata` twice, 180s apart, on 2026-08-24:

| Chain | Blocks processed in 180s | Last ChainMetricValues |
| --- | --- | --- |
| Ethereum | 14 | 2026-08-24 |
| Arbitrum | 0 | 2026-08-19 |
| Base | 0 | 2026-08-19 |
| Berachain | 0 | 2026-08-19 |
| Fantom | 0 | 2026-08-19 |
| Polygon | 0 | 2026-08-19 |

All six share one `timestamp_caught_up_to_head_or_endblock`, `2026-08-19T17:16:23.285Z`. The five quiet chains stopped the moment they reached the head. Ethereum is the only one with events at the tip, so it kept going. `GlobalMetricSnapshot` shows `chainsIndexed=[1]` from 08-20 on, which is what pins `crossChainComplete` and holds the published bound at 08-19.

Two things make this easy to misread. The fetcher stays alive on a frozen chain: at 19:55 the Fantom source logged `knownHeight: 123018300` against a stored `block_height` of `122948711`. And `behind 0` in `chain_metadata` means nothing here, because a wedged chain stops updating its own `block_height` too, so it reads as caught up while sitting five days back.

3.6.1's fix is "edge case when a single chain might freeze at the head when there are no events in the last 30k blocks" (enviodev/hyperindex#1535). Checking that trigger against HyperSync, using the wallet-filtered Transfer selection the indexer actually subscribes to. All five frozen chains have been dry to the current head, in blocks:

| Chain | Dry before it wedged | Dry since, to head | Over 30k |
| --- | --- | --- | --- |
| Arbitrum | 948 | 1,744,632 | yes |
| Fantom | 21,437 | 69,840 | yes |
| Berachain | 32,588 | 220,897 | yes |
| Polygon | 59,422 | 292,887 | yes |
| Base | 4,447,539 | 221,287 | yes |

Base is the clearest signal. It backfilled through 4.45m dry blocks without freezing, then froze once it hit the head. So this is head behaviour, not dry stretches in general, which is what the release note describes. Arbitrum and Fantom wedged only 948 and 21,437 blocks into their dry stretch, so a chain doesn't need 30k of prior quiet to hit this, it just needs to run out of matching events at the head.

Not validated: that's the Transfer selection only. The non-Transfer subscriptions (Univ3 swaps, Balancer, staking) aren't wallet-filtered, and an address-only query does return logs within 10 blocks of Arbitrum's last write. Reconstructing the exact topic set needs codegen, so the attribution is well supported, not proven. I also haven't seen 3.6.1 hold at the head on our own chains, and won't until the reindex finishes.

Still **not** a fix for the `envio_checkpoints` crash above. Nothing in 3.4.0 through 3.6.1 addresses checkpoint writes, duplicate keys, or write races, and that still looks like an upstream bug worth reporting. 3.5.1 fixes a dynamic contract registration edge case.

Version choice: 3.6.1 is the registry `latest` tag, published 2026-08-07, so at 12 days old it clears the 7 day `minimumReleaseAge` on its own and the 3.3.2 exclusions in `pnpm-workspace.yaml` can go. 3.7.0 is under the `next` tag and one day old, so it is skipped.

Breaking changes reviewed:

- 3.6.0 per-chain entity scoping is opt-in behind `disable_default_cross_chain` and is left off. Entity IDs and cross-chain reads are unchanged. It becomes the default in v4, so that is a separate decision later.
- 3.4.0 allows multiple `onEvent` handlers per event and moves test indexer instances in-process, which the release notes say can cause shared state pollution in edge cases. Our test suite is clean.
- 3.5.0 adds Int and BigInt entity IDs, defers schema indexes until after backfill, and widens the DB type for chain IDs above 2^31. All additive for us.

No handler, schema, or config changes were needed.

## Verification

- New publisher regression test fails on the old code, passes with the guard.
- `tsc --noEmit` clean across the whole repo after codegen against 3.6.1, with no handler changes.
- Indexer suite 138 passed, 3 skipped. The 3 skipped are the live HyperSync tests, which pass when run from `apps/indexer` with `ENVIO_API_TOKEN` loaded: BackfillTokenBalances on Arbitrum and Berachain, and Berachain POL pricing, 3 passed in 112s.
- metrics-publisher 37/37, metrics-api 30/30, client 22/22.
- `biome check .` clean, `pnpm install --frozen-lockfile` clean.
- The 3 root-level failures are pre-existing and unrelated. The live tests cannot resolve `config.yaml` when vitest runs from the repo root; they pass from `apps/indexer`.

## Sequencing

This section used to say wait until published bounds were back at today's date before merging. That's now backwards. Bounds can't reach today while the chains are frozen, and only this PR unfreezes them, so waiting is a deadlock. Merge it.

Merging redeploys the indexer, resets it, and starts another roughly 5 hour reindex. Change 1 is what makes that safe: the publisher skips with `reindex_in_progress` and the manifest holds at 2026-08-19, so the site stays stale rather than going blank. Bounds move once all six chains pass 2026-08-19.

Both changes need to ship together. Change 1 alone leaves the chains frozen. Change 2 alone means the reindex drags published bounds backwards and blanks the pages, which is the incident at the top of this PR.

## Not addressed here

- `-r` fires on every container start, not just deploys, so any crash still costs a full reindex. With this fix that is invisible to clients, but it also means the reset destroys the evidence of whatever caused the crash. The duplicate row is already gone.
- Railway is dropping this service's logs at the 500 logs/sec replica limit, in batches of up to 780 messages, which is why this took narrow time-window queries to find.
- Nothing alerts when the publisher holds. If the indexer ever crash-looped, the API would serve the same frozen day indefinitely and the pages would look fine. A check on `/v2/bounds` `latestDate` falling behind today would cover this and the frozen-lock bug from last week.
