### PR TITLE
fix(indexer): survive a Postgres restart instead of staying crashed

### DIFF
--- a/apps/indexer/src/start-envio.ts
+++ b/apps/indexer/src/start-envio.ts
@@ -1,6 +1,20 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { createConnection } from "node:net";
 import { pathToFileURL } from "node:url";
 import { validateIndexerEnv } from "./validate-env";
+
+// Envio treats a failed batch write as a fatal error and exits (see
+// IndexerState.res `recordWriteFailure` -> Bin.res `Main.FatalError`). It has no
+// reconnect on the write loop, so a Postgres restart underneath a running
+// indexer kills the process. Railway's restart policy alone is not enough: the
+// container comes back faster than Postgres finishes crash recovery, burns its
+// retries against a refused connection, and the service stays crashed. These
+// bounds let the wrapper outlive a database restart instead.
+export const MAX_ENVIO_RESPAWNS = 10;
+export const MIN_HEALTHY_RUNTIME_MS = 60_000;
+export const DATABASE_WAIT_TIMEOUT_MS = 10 * 60_000;
+export const DATABASE_PROBE_INTERVAL_MS = 2_000;
+export const DATABASE_PROBE_TIMEOUT_MS = 5_000;
 
 export function prepareIndexerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const railwayPort = env.PORT?.trim();
@@ -17,8 +31,20 @@ export function isRailwayRuntime(env: NodeJS.ProcessEnv): boolean {
   return Object.entries(env).some(([key, value]) => key.startsWith("RAILWAY_") && isPresent(value));
 }
 
-export function resolveEnvioArgs(args: string[], env: NodeJS.ProcessEnv = process.env): string[] {
+export function resolveEnvioArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  options: { respawn?: boolean } = {},
+): string[] {
   const resolvedArgs = args.length === 0 ? ["start"] : args;
+
+  // A respawn re-enters a database whose schema this same deployment already
+  // created; resetting again would throw away every block indexed since. Drop
+  // the reset so the indexer resumes where the crash left it.
+  if (options.respawn) {
+    return resolvedArgs.filter((arg) => arg !== "-r" && arg !== "--reset");
+  }
+
   if (!isRailwayRuntime(env) || resolvedArgs[0] !== "start" || hasResetFlag(resolvedArgs)) {
     return resolvedArgs;
   }
@@ -26,10 +52,193 @@ export function resolveEnvioArgs(args: string[], env: NodeJS.ProcessEnv = proces
   return [...resolvedArgs, "-r"];
 }
 
-export function runIndexerStartup(
+export function probeDatabase(
+  host: string,
+  port: number,
+  timeoutMs: number = DATABASE_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    const settle = (reachable: boolean) => {
+      socket.destroy();
+      resolve(reachable);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => settle(true));
+    socket.once("timeout", () => settle(false));
+    socket.once("error", () => settle(false));
+  });
+}
+
+export async function waitForDatabase(
+  env: NodeJS.ProcessEnv,
+  options: {
+    probe?: (host: string, port: number) => Promise<boolean>;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+    logInfo?: (message: string) => void;
+    timeoutMs?: number;
+    intervalMs?: number;
+  } = {},
+): Promise<boolean> {
+  const probe = options.probe ?? ((host, port) => probeDatabase(host, port));
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  const logInfo = options.logInfo ?? console.error;
+  const timeoutMs = options.timeoutMs ?? DATABASE_WAIT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DATABASE_PROBE_INTERVAL_MS;
+
+  const host = env.ENVIO_PG_HOST?.trim() ?? "";
+  const port = Number(env.ENVIO_PG_PORT);
+  if (host === "" || !Number.isInteger(port) || port <= 0) {
+    // validateIndexerEnv already rejects this before the first spawn; treat an
+    // unusable address as "do not block" rather than hanging the container.
+    return false;
+  }
+
+  const deadline = now() + timeoutMs;
+  logInfo(`Waiting up to ${Math.round(timeoutMs / 1000)}s for Postgres at ${host}:${port}`);
+
+  for (;;) {
+    if (await probe(host, port)) {
+      logInfo(`Postgres at ${host}:${port} is accepting connections`);
+      return true;
+    }
+
+    if (now() >= deadline) {
+      logInfo(`Postgres at ${host}:${port} still unreachable after ${timeoutMs}ms`);
+      return false;
+    }
+
+    await sleep(intervalMs);
+  }
+}
+
+export type EnvioSupervisorOptions = {
+  spawnEnvio?: (args: string[], env: NodeJS.ProcessEnv) => Pick<ChildProcess, "on">;
+  waitForDatabase?: (env: NodeJS.ProcessEnv) => Promise<boolean>;
+  logError?: (message: string) => void;
+  logInfo?: (message: string) => void;
+  exit?: (code?: number) => never;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  pid?: number;
+  now?: () => number;
+  maxRespawns?: number;
+  minHealthyRuntimeMs?: number;
+};
+
+export async function superviseEnvio(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  options: EnvioSupervisorOptions = {},
+): Promise<void> {
+  const logError = options.logError ?? console.error;
+  const logInfo = options.logInfo ?? console.error;
+  const spawnEnvio =
+    options.spawnEnvio ??
+    ((spawnArgs, spawnEnv) => spawn("envio", spawnArgs, { env: spawnEnv, stdio: "inherit" }));
+  const waitForDatabaseFn =
+    options.waitForDatabase ?? ((waitEnv) => waitForDatabase(waitEnv, { logInfo }));
+  const exit = options.exit ?? process.exit;
+  const maxRespawns = options.maxRespawns ?? MAX_ENVIO_RESPAWNS;
+  const minHealthyRuntimeMs = options.minHealthyRuntimeMs ?? MIN_HEALTHY_RUNTIME_MS;
+  const now = options.now ?? Date.now;
+
+  const initialArgs = resolveEnvioArgs(args, env);
+  let nextArgs = initialArgs;
+  let respawns = 0;
+
+  for (;;) {
+    const startedAt = now();
+    const outcome = await runEnvioOnce(spawnEnvio(nextArgs, env), {
+      kill: options.kill,
+      pid: options.pid,
+    });
+    const runtimeMs = now() - startedAt;
+
+    if (outcome.type === "signal") {
+      // The container is being torn down. Existing behaviour: re-raise on self
+      // so the exit status reflects the signal. Never respawn.
+      return;
+    }
+
+    if (outcome.type === "spawnError") {
+      logError(formatEnvioSpawnError(outcome.error));
+      exit(1);
+      return;
+    }
+
+    const code = outcome.code ?? 1;
+    if (code === 0) {
+      exit(0);
+      return;
+    }
+
+    // A run that survived past startup proves the schema is usable, so its
+    // budget is refunded and the retry may resume rather than reset.
+    const startedCleanly = runtimeMs >= minHealthyRuntimeMs;
+    if (startedCleanly) {
+      respawns = 0;
+    }
+
+    if (respawns >= maxRespawns) {
+      logError(
+        `Envio exited with code ${code} and has been respawned ${respawns} times; giving up so Railway can restart the container`,
+      );
+      exit(code);
+      return;
+    }
+
+    logError(`Envio exited with code ${code} after ${runtimeMs}ms; checking Postgres before retry`);
+    const databaseReachable = await waitForDatabaseFn(env);
+    if (!databaseReachable) {
+      logError("Postgres did not become reachable; exiting so Railway can restart the container");
+      exit(code);
+      return;
+    }
+
+    respawns += 1;
+    // A crash before the first healthy run may have left an incomplete schema
+    // (for example a failure during the reset itself), so repeat the original
+    // arguments. Only a run that got properly under way is safe to resume.
+    nextArgs = startedCleanly ? resolveEnvioArgs(args, env, { respawn: true }) : initialArgs;
+    logInfo(`Restarting envio (attempt ${respawns}/${maxRespawns}): envio ${nextArgs.join(" ")}`);
+  }
+}
+
+type EnvioOutcome =
+  | { type: "exit"; code: number | null }
+  | { type: "signal"; signal: NodeJS.Signals }
+  | { type: "spawnError"; error: Error & { code?: string } };
+
+function runEnvioOnce(
+  child: Pick<ChildProcess, "on">,
+  options: { kill?: (pid: number, signal: NodeJS.Signals) => void; pid?: number } = {},
+): Promise<EnvioOutcome> {
+  const kill = options.kill ?? process.kill;
+  const pid = options.pid ?? process.pid;
+
+  return new Promise((resolve) => {
+    child.on("error", (error) => {
+      resolve({ type: "spawnError", error });
+    });
+
+    child.on("exit", (code, signal) => {
+      if (signal !== null) {
+        kill(pid, signal);
+        resolve({ type: "signal", signal });
+        return;
+      }
+      resolve({ type: "exit", code });
+    });
+  });
+}
+
+export async function runIndexerStartup(
   args: string[] = process.argv.slice(2),
   env: NodeJS.ProcessEnv = process.env,
-): void {
+): Promise<void> {
   const preparedEnv = prepareIndexerEnv(env);
   validateIndexerEnv(preparedEnv);
 
@@ -37,40 +246,7 @@ export function runIndexerStartup(
     return;
   }
 
-  const child = spawn("envio", resolveEnvioArgs(args, preparedEnv), {
-    env: preparedEnv,
-    stdio: "inherit",
-  });
-
-  attachEnvioChildHandlers(child);
-}
-
-export function attachEnvioChildHandlers(
-  child: Pick<ChildProcess, "on">,
-  options: {
-    logError?: (message: string) => void;
-    exit?: (code?: number) => never;
-    kill?: (pid: number, signal: NodeJS.Signals) => void;
-    pid?: number;
-  } = {},
-): void {
-  const logError = options.logError ?? console.error;
-  const exit = options.exit ?? process.exit;
-  const kill = options.kill ?? process.kill;
-  const pid = options.pid ?? process.pid;
-
-  child.on("error", (error) => {
-    logError(formatEnvioSpawnError(error));
-    exit(1);
-  });
-
-  child.on("exit", (code, signal) => {
-    if (signal !== null) {
-      kill(pid, signal);
-      return;
-    }
-    exit(code ?? 1);
-  });
+  await superviseEnvio(args, preparedEnv);
 }
 
 export function formatEnvioSpawnError(error: Error & { code?: string }): string {
@@ -78,6 +254,10 @@ export function formatEnvioSpawnError(error: Error & { code?: string }): string 
     return `Failed to start envio: envio binary was not found in PATH (${error.message})`;
   }
   return `Failed to start envio: ${error.code ? `${error.code}: ` : ""}${error.message}`;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function hasResetFlag(args: string[]): boolean {
@@ -89,5 +269,8 @@ function isPresent(value: string | undefined): boolean {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  runIndexerStartup();
+  runIndexerStartup().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }

--- a/apps/indexer/tests/env.test.ts
+++ b/apps/indexer/tests/env.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "vitest";
 
 import {
-  attachEnvioChildHandlers,
+  type EnvioSupervisorOptions,
   formatEnvioSpawnError,
   isRailwayRuntime,
   prepareIndexerEnv,
   resolveEnvioArgs,
+  superviseEnvio,
+  waitForDatabase,
 } from "../src/start-envio";
 import { validateIndexerEnv } from "../src/validate-env";
 
@@ -131,31 +133,21 @@ describe("indexer env validation", () => {
     ).toBe("Failed to start envio: EACCES: permission denied");
   });
 
-  test("attaches a spawn error handler that logs and exits", () => {
-    const handlers = new Map<string, (first: unknown, second?: unknown) => void>();
-    const child = {
-      on: (event: string, handler: (first: unknown, second?: unknown) => void) => {
-        handlers.set(event, handler);
-        return child;
-      },
+  test("resumes instead of resetting when respawning after a crash", () => {
+    const railwayEnv = {
+      ...validEnv,
+      ENVIO_INDEXER_PORT: "9898",
+      ENVIO_PG_SCHEMA: "",
+      PORT: "9898",
+      RAILWAY_SERVICE_ID: "railway-service-1",
     };
-    const logged: string[] = [];
-    const exits: number[] = [];
 
-    attachEnvioChildHandlers(child as Parameters<typeof attachEnvioChildHandlers>[0], {
-      logError: (message) => logged.push(message),
-      exit: (code) => {
-        exits.push(code ?? 0);
-        throw new Error(`exit ${code}`);
-      },
-    });
-
-    expect(handlers.has("error")).toBe(true);
-    expect(() =>
-      handlers.get("error")?.(Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" })),
-    ).toThrow("exit 1");
-    expect(logged[0]).toContain("envio binary was not found in PATH");
-    expect(exits).toEqual([1]);
+    expect(resolveEnvioArgs([], railwayEnv, { respawn: true })).toEqual(["start"]);
+    expect(resolveEnvioArgs(["start"], railwayEnv, { respawn: true })).toEqual(["start"]);
+    expect(resolveEnvioArgs(["start", "-r"], railwayEnv, { respawn: true })).toEqual(["start"]);
+    expect(resolveEnvioArgs(["start", "--reset"], railwayEnv, { respawn: true })).toEqual([
+      "start",
+    ]);
   });
 
   test("fails loudly when required env variables are missing", () => {
@@ -183,5 +175,243 @@ describe("indexer env validation", () => {
         ENVIO_INDEXER_PORT: "0",
       }),
     ).toThrow("Invalid positive integer environment variables: ENVIO_INDEXER_PORT");
+  });
+});
+
+const railwayEnv: NodeJS.ProcessEnv = {
+  ...validEnv,
+  ENVIO_INDEXER_PORT: "9898",
+  ENVIO_PG_SCHEMA: "",
+  PORT: "9898",
+  RAILWAY_SERVICE_ID: "railway-service-1",
+};
+
+type ScriptedRun = {
+  code?: number | null;
+  signal?: NodeJS.Signals;
+  error?: Error & { code?: string };
+  runtimeMs?: number;
+};
+
+type EnvioChild = ReturnType<NonNullable<EnvioSupervisorOptions["spawnEnvio"]>>;
+
+function scriptedChild(run: ScriptedRun): EnvioChild {
+  const child = {
+    on(event: string, handler: (...args: never[]) => void) {
+      if (event === "exit" && run.error === undefined) {
+        queueMicrotask(() =>
+          (handler as (code: number | null, signal: NodeJS.Signals | null) => void)(
+            run.code ?? null,
+            run.signal ?? null,
+          ),
+        );
+      }
+      if (event === "error" && run.error !== undefined) {
+        queueMicrotask(() => (handler as (error: Error) => void)(run.error as Error));
+      }
+      return child;
+    },
+  };
+
+  return child as unknown as EnvioChild;
+}
+
+function harness(runs: ScriptedRun[], databaseReachable: boolean[] = []) {
+  const spawnedArgs: string[][] = [];
+  const logged: string[] = [];
+  const exits: number[] = [];
+  let clock = 0;
+  let runIndex = 0;
+  let waitIndex = 0;
+
+  const options = {
+    spawnEnvio: (args: string[]) => {
+      const run = runs[runIndex++];
+      if (run === undefined) {
+        throw new Error(`envio was spawned ${runIndex} times but only ${runs.length} are scripted`);
+      }
+      spawnedArgs.push(args);
+      clock += run.runtimeMs ?? 0;
+      return scriptedChild(run);
+    },
+    waitForDatabase: async () => databaseReachable[waitIndex++] ?? true,
+    logError: (message: string) => logged.push(message),
+    logInfo: (message: string) => logged.push(message),
+    exit: ((code?: number) => {
+      exits.push(code ?? 0);
+      throw new Error(`exit ${code}`);
+    }) as (code?: number) => never,
+    kill: () => {},
+    pid: 1234,
+    now: () => clock,
+  };
+
+  return { options, spawnedArgs, logged, exits };
+}
+
+describe("envio supervisor", () => {
+  test("respawns without resetting after a healthy run crashes", async () => {
+    const { options, spawnedArgs, exits } = harness([
+      { code: 1, runtimeMs: 5 * 60_000 },
+      { code: 1, runtimeMs: 5 * 60_000 },
+      { signal: "SIGTERM", runtimeMs: 5 * 60_000 },
+    ]);
+
+    await expect(
+      superviseEnvio([], railwayEnv, { ...options, maxRespawns: 2 }),
+    ).resolves.toBeUndefined();
+
+    // First boot resets, every respawn resumes.
+    expect(spawnedArgs).toEqual([["start", "-r"], ["start"], ["start"]]);
+    expect(exits).toEqual([]);
+  });
+
+  test("refunds the respawn budget after each healthy run", async () => {
+    const runs: ScriptedRun[] = Array.from({ length: 12 }, () => ({
+      code: 1,
+      runtimeMs: 5 * 60_000,
+    }));
+    runs.push({ signal: "SIGTERM", runtimeMs: 5 * 60_000 });
+    const { options, spawnedArgs } = harness(runs);
+
+    await expect(
+      superviseEnvio([], railwayEnv, { ...options, maxRespawns: 2 }),
+    ).resolves.toBeUndefined();
+
+    // Every crash clears MIN_HEALTHY_RUNTIME_MS, so the two-respawn budget is
+    // refunded each time and never runs out over 12 successive crashes.
+    expect(spawnedArgs.length).toBe(13);
+  });
+
+  test("repeats the reset when the crash happened before a healthy run", async () => {
+    const { options, spawnedArgs } = harness([
+      { code: 1, runtimeMs: 500 },
+      { code: 1, runtimeMs: 500 },
+      { code: 1, runtimeMs: 500 },
+    ]);
+
+    await expect(superviseEnvio([], railwayEnv, { ...options, maxRespawns: 2 })).rejects.toThrow(
+      "exit 1",
+    );
+
+    // A crash during startup may have left a half-created schema, so the reset
+    // is repeated rather than resumed.
+    expect(spawnedArgs).toEqual([
+      ["start", "-r"],
+      ["start", "-r"],
+      ["start", "-r"],
+    ]);
+  });
+
+  test("gives up to Railway once the respawn budget is exhausted", async () => {
+    const runs = Array.from({ length: 5 }, () => ({ code: 1, runtimeMs: 500 }));
+    const { options, spawnedArgs, exits, logged } = harness(runs);
+
+    await expect(superviseEnvio([], railwayEnv, { ...options, maxRespawns: 2 })).rejects.toThrow(
+      "exit 1",
+    );
+
+    expect(spawnedArgs.length).toBe(3);
+    expect(exits).toEqual([1]);
+    expect(logged.some((message) => message.includes("giving up so Railway can restart"))).toBe(
+      true,
+    );
+  });
+
+  test("exits when Postgres never comes back", async () => {
+    const { options, spawnedArgs, exits, logged } = harness(
+      [{ code: 1, runtimeMs: 5 * 60_000 }, { code: 1 }],
+      [false],
+    );
+
+    await expect(superviseEnvio([], railwayEnv, options)).rejects.toThrow("exit 1");
+
+    expect(spawnedArgs.length).toBe(1);
+    expect(exits).toEqual([1]);
+    expect(logged.some((message) => message.includes("did not become reachable"))).toBe(true);
+  });
+
+  test("does not respawn when Envio is terminated by a signal", async () => {
+    const { options, spawnedArgs, exits } = harness([{ signal: "SIGTERM", runtimeMs: 60_000 }]);
+
+    await expect(superviseEnvio([], railwayEnv, options)).resolves.toBeUndefined();
+
+    expect(spawnedArgs.length).toBe(1);
+    expect(exits).toEqual([]);
+  });
+
+  test("logs and exits when envio cannot be spawned at all", async () => {
+    const { options, exits, logged } = harness([
+      { error: Object.assign(new Error("spawn envio ENOENT"), { code: "ENOENT" }) },
+    ]);
+
+    await expect(superviseEnvio([], railwayEnv, options)).rejects.toThrow("exit 1");
+
+    expect(exits).toEqual([1]);
+    expect(logged[0]).toContain("envio binary was not found in PATH");
+  });
+
+  test("exits cleanly when Envio finishes successfully", async () => {
+    const { options, exits } = harness([{ code: 0, runtimeMs: 60_000 }]);
+
+    await expect(superviseEnvio([], railwayEnv, options)).rejects.toThrow("exit 0");
+
+    expect(exits).toEqual([0]);
+  });
+});
+
+describe("postgres readiness probe", () => {
+  test("returns once the database accepts a connection", async () => {
+    const attempts: number[] = [];
+    let clock = 0;
+
+    const reachable = await waitForDatabase(railwayEnv, {
+      probe: async () => {
+        attempts.push(clock);
+        return attempts.length === 3;
+      },
+      sleep: async (ms) => {
+        clock += ms;
+      },
+      now: () => clock,
+      logInfo: () => {},
+      intervalMs: 2_000,
+      timeoutMs: 60_000,
+    });
+
+    expect(reachable).toBe(true);
+    expect(attempts).toEqual([0, 2_000, 4_000]);
+  });
+
+  test("gives up after the wait window elapses", async () => {
+    let clock = 0;
+
+    const reachable = await waitForDatabase(railwayEnv, {
+      probe: async () => false,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+      now: () => clock,
+      logInfo: () => {},
+      intervalMs: 2_000,
+      timeoutMs: 10_000,
+    });
+
+    expect(reachable).toBe(false);
+    expect(clock).toBeGreaterThanOrEqual(10_000);
+  });
+
+  test("does not block when the Postgres address is unusable", async () => {
+    const reachable = await waitForDatabase(
+      { ...railwayEnv, ENVIO_PG_HOST: "  " },
+      {
+        probe: async () => {
+          throw new Error("probe must not run");
+        },
+        logInfo: () => {},
+      },
+    );
+
+    expect(reachable).toBe(false);
   });
 });

--- a/docs/railway-metrics-api.md
+++ b/docs/railway-metrics-api.md
@@ -100,6 +100,14 @@ check requires the core variables below before Envio starts.
   Envio tables in the default schema before indexing. That is intentional:
   Postgres/Hasura is not the public availability boundary for this service.
   Published artifact snapshots and the metrics API are the handover boundary.
+- The startup wrapper supervises Envio rather than exiting with it. Envio treats
+  a failed batch write as fatal, so a Postgres restart underneath a running
+  indexer kills the process. On an unexpected exit the wrapper waits for
+  Postgres to accept connections again (up to ten minutes) and respawns Envio
+  as plain `envio start` — no `-r` — so the indexer resumes rather than
+  replaying from the beginning. A crash inside the first minute is treated as a
+  failed startup instead and repeats the original `-r`, because a run that never
+  got under way may have left the schema half-created.
 - Required `ENVIO_PG_SSL_MODE`: set according to the Railway Postgres
   connection mode. Envio accepts `false`, `true`, `require`, `allow`, `prefer`,
   or `verify-full`; it does not accept libpq-style `disable`.
@@ -152,8 +160,11 @@ for event ingestion.
 Railway deployment flow:
 
 1. A new indexer deployment starts with `envio start -r` against Envio's default
-   schema. Any restart of the indexer container does the same, including
-   platform-initiated restarts that keep the current deployment.
+   schema. Any restart of the indexer *container* does the same, including
+   platform-initiated restarts that keep the current deployment. An in-process
+   respawn after an Envio crash does not: the wrapper resumes the existing
+   schema, so a transient Postgres outage costs seconds rather than a full
+   reindex.
 2. Existing metric artifacts remain in the bucket, and `metrics-api` continues
    serving the currently published manifest while the indexer reindexes.
 3. The publisher cron reads Hasura but skips cleanly with

--- a/railway-indexer.json
+++ b/railway-indexer.json
@@ -17,6 +17,6 @@
     "healthcheckPath": "/healthz",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 1
+    "restartPolicyMaxRetries": 10
   }
 }

--- a/tests/railway/config.test.ts
+++ b/tests/railway/config.test.ts
@@ -57,7 +57,11 @@ describe("Railway config-as-code", () => {
     expect(hasura.deploy.restartPolicyMaxRetries).toBe(1);
     expect(indexer.deploy.healthcheckPath).toBe("/healthz");
     expect(indexer.deploy.restartPolicyType).toBe("ON_FAILURE");
-    expect(indexer.deploy.restartPolicyMaxRetries).toBe(1);
+    // Envio exits on a failed batch write, so a Postgres restart takes the
+    // indexer down with it. One retry is consumed long before Postgres finishes
+    // crash recovery; the wrapper's own supervisor handles the common case and
+    // this is the backstop for anything that kills the wrapper too.
+    expect(indexer.deploy.restartPolicyMaxRetries).toBe(10);
     expect(api.deploy.healthcheckPath).toBe("/ready");
     expect(api.deploy.restartPolicyType).toBe("ON_FAILURE");
     expect(api.deploy.restartPolicyMaxRetries).toBe(1);


### PR DESCRIPTION
The indexer sat Crashed for two days after a four minute Postgres blip. This makes it come back on its own.

## What happened

Railway restarted the production Postgres container on 2026-08-29. It ran crash recovery and was unreachable for about four minutes ("database system was not properly shut down", stale postmaster.pid, volume remount).

The indexer tried to flush a batch in that window and got ECONNREFUSED on both the IPv6 and IPv4 addresses. Envio treats a failed batch write as fatal (`IndexerState.res` `recordWriteFailure` into `Bin.res` `Main.FatalError`) and has no reconnect on the write loop, so the process dies with the database.

`restartPolicyMaxRetries` was 1, and the single retry was spent while Postgres was still refusing connections. Postgres accepted connections 4 seconds after the indexer gave up. It stayed Crashed until it was redeployed by hand two days later.

Worth saying plainly: #353 was the deployment that died, but it didn't cause this. It had been indexing fine for three days, and there's exactly one ERROR line in its last 3000 log lines.

## The fix

The startup wrapper now supervises Envio instead of exiting with it.

- On an unexpected exit, probe Postgres over TCP every 2s for up to 10 minutes, then respawn.
- Respawn as plain `envio start`, not `start -r`. The schema this deployment created is still there, so resuming costs seconds where a reset costs a full replay from 2022.
- A crash inside the first minute repeats the original `-r` instead. A run that never got under way may have left the schema half-created, so resuming it isn't safe.
- The respawn budget is refunded after any run that clears the healthy threshold, so unrelated crashes months apart don't accumulate.
- `restartPolicyMaxRetries` goes from 1 to 10, as the backstop for anything that takes the wrapper down too.

`docs/railway-metrics-api.md` said every restart resets. That's now split: container restarts still reset, in-process respawns resume.

## Not validated

The supervisor is covered by unit tests using a scripted child process and a fake clock. It has not been exercised against a real Postgres restart. The honest test is to bounce Postgres in a PR environment and watch the indexer resume without reindexing, and I haven't done that.

Production was redeployed separately and is Online and reindexing now.

## Verification

- `pnpm run check`, `pnpm run build`
- all six suites: root, artifacts, client, metrics-api, metrics-publisher, indexer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved indexer resilience by automatically retrying after unexpected failures.
  * Waits for the database to become available before resuming indexing.
  * Resumes existing indexing progress after transient database outages instead of restarting from scratch.
  * Allows up to 10 deployment-level restart attempts.

* **Documentation**
  * Updated deployment documentation to explain indexer recovery and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->