### PR TITLE
fix(security): clear dependency and Hasura image findings

### DIFF
--- a/Dockerfile-hasura
+++ b/Dockerfile-hasura
@@ -26,6 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get update \
     libpam-modules-bin \
     libpam-runtime \
     libpam0g \
+    libp11-kit0 \
     libperl5.34 \
     libpq5 \
     libpython3.10-minimal \

--- a/Dockerfile-hasura
+++ b/Dockerfile-hasura
@@ -4,9 +4,11 @@ RUN DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get update \
     bsdutils \
     coreutils \
     curl \
+    diffutils \
     distro-info-data \
     gcc-12-base \
     gzip \
+    libattr1 \
     libblkid1 \
     libcap2 \
     libc-bin \

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.6.1",
+    "envio": "3.8.0",
     "viem": "2.53.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "bignumber.js": "9.1.2",
-    "envio": "3.6.1",
+    "envio": "3.8.0",
     "tsx": "4.22.4",
     "viem": "2.53.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,9 +46,9 @@ overrides:
   yaml@<2.8.3: 2.8.3
   body-parser@<1.20.6: 1.20.6
   cookie@<0.7.0: 0.7.0
-  express@<4.20.0: 4.20.0
+  express@<4.22.2: 4.22.2
   path-to-regexp@<0.1.13: 0.1.13
-  qs@<6.15.2: 6.15.2
+  qs@<6.16.0: 6.16.0
   send@<0.19.0: 0.19.0
   serve-static@<1.16.0: 1.16.0
   postcss@<8.5.23: 8.5.23
@@ -65,8 +65,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.6.1
-        version: 3.6.1(react-dom@19.2.6(react@19.2.6))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.8.0
+        version: 3.8.0(react-dom@19.2.6(react@19.2.6))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -95,8 +95,8 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
       envio:
-        specifier: 3.6.1
-        version: 3.6.1(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
+        specifier: 3.8.0
+        version: 3.8.0(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76)
       viem:
         specifier: 2.53.1
         version: 2.53.1(typescript@6.0.3)(zod@3.25.76)
@@ -898,8 +898,8 @@ packages:
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
-  cookie@0.7.0:
-    resolution: {integrity: sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   date-fns@3.3.1:
@@ -964,36 +964,36 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  envio-darwin-arm64@3.6.1:
-    resolution: {integrity: sha512-ecGuGkptoCbfH5ULq4yAhRRB8pAK8pzQp6JahmBsH7dYSOmgM8xQRqgS5QwVgjrfQWl5GH3S4dyZpnSsCNcy+w==}
+  envio-darwin-arm64@3.8.0:
+    resolution: {integrity: sha512-gRb+Ddf30RF0T/Q8kyQ2nnNdVO33O4fmyHk5ZqHYb55YcWBCB0vUKKehtxXUSSlaBchE9VM7J7KEQNeN2ilpww==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@3.6.1:
-    resolution: {integrity: sha512-zADvYOhv8Yjsp4a5AooJg4kRPKcidyjljru8XpUIIvLq5VdHQcs/5r1EnhDwPgA2Y9gBqTNCWZJ80pQs6Vg/0g==}
+  envio-darwin-x64@3.8.0:
+    resolution: {integrity: sha512-WiHlgHeFM9y9Pl32i404Q1XMSEqcL14Y3Wqa0Xunje8dZrazsUjRzv6B9jsbILGk+FZRNnMVzfmCRSCm0PEodA==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@3.6.1:
-    resolution: {integrity: sha512-dTbMq6BtAn0tEduGHdunyomIVNVTx32pr7tzRDdJ/rlPQxdNDkKboPIFeuxMoTiLKtUIyrkDRb/KZUNna72suQ==}
+  envio-linux-arm64@3.8.0:
+    resolution: {integrity: sha512-Ul6AJp7gaq5PWabYp2Cwi83DQ86ujgdCbxXxBfGborZFgf8WrXcjWhtBdzgUKKCBBhghqeX9Mq39UYj3c7L+Dg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.6.1:
-    resolution: {integrity: sha512-APwQYvKhzMEsrWsKAhjx2+p8kqJi00Oz46YyW7Ln005pt96Am6ACqC7pWoo5J5Zuui8Y2lR4wJmEWKZeH9pkRQ==}
+  envio-linux-x64-musl@3.8.0:
+    resolution: {integrity: sha512-R7LZezepplRqUVr08zxYrwpfqPyPFyqwUnCh2fKIDwDoqum3XNVN0dfiwbFYrzcm9qdBYD0uJF0BcKsykL/aEw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  envio-linux-x64@3.6.1:
-    resolution: {integrity: sha512-eynhAQXaEimq/QT0REEXPqjAs3J7rURymL7PRSXBvrfQVUUKjiO4l5S9jL5jlSpWpZR4o2xcW6xZAuk7O1B9sw==}
+  envio-linux-x64@3.8.0:
+    resolution: {integrity: sha512-I6D4sL4BTbyDjp6a0TDioqkQcCXfmNHP4J9POZ3wsVbYLnl6czho38+vomQzVpXtSmz7aXa82H1zZ6/g3Bncxg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  envio@3.6.1:
-    resolution: {integrity: sha512-n8N3ih7rEL6saDTXPOI1sxwruaD4HfJBtNnrlrmDDzv9Ccj8IFElBQJc+JvSIfT8TwzVZynPiHiL6e/gvtc7fg==}
+  envio@3.8.0:
+    resolution: {integrity: sha512-phvUx5JYeBTAABjzsAGkcSDBXOQfJMV8jtWU5x4faHKzxCfno3vTm2S2YYVUhbwrNivjBN1aMCtorBfnW8x0Yg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1057,8 +1057,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.20.0:
-    resolution: {integrity: sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==}
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
   fast-copy@4.0.3:
@@ -1096,8 +1096,8 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
-  finalhandler@1.2.0:
-    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
   forwarded@0.2.0:
@@ -1487,8 +1487,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -1578,8 +1578,12 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
-  serve-static@1.16.0:
-    resolution: {integrity: sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==}
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
 
   setprototypeof@1.2.0:
@@ -1597,8 +1601,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2611,7 +2615,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -2695,7 +2699,7 @@ snapshots:
 
   cookie-signature@1.0.6: {}
 
-  cookie@0.7.0: {}
+  cookie@0.7.2: {}
 
   date-fns@3.3.1: {}
 
@@ -2739,22 +2743,22 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@3.6.1:
+  envio-darwin-arm64@3.8.0:
     optional: true
 
-  envio-darwin-x64@3.6.1:
+  envio-darwin-x64@3.8.0:
     optional: true
 
-  envio-linux-arm64@3.6.1:
+  envio-linux-arm64@3.8.0:
     optional: true
 
-  envio-linux-x64-musl@3.6.1:
+  envio-linux-x64-musl@3.8.0:
     optional: true
 
-  envio-linux-x64@3.6.1:
+  envio-linux-x64@3.8.0:
     optional: true
 
-  envio@3.6.1(react-dom@19.2.6(react@19.2.6))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+  envio@3.8.0(react-dom@19.2.6(react@19.2.6))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2769,7 +2773,7 @@ snapshots:
       date-fns: 3.3.1
       dotenv: 16.4.5
       eventsource: 4.1.0
-      express: 4.20.0
+      express: 4.22.2
       ink: 6.8.0(react@19.2.6)
       ink-big-text: 2.0.0(ink@6.8.0(react@19.2.6))(react@19.2.6)
       ink-spinner: 5.0.0(ink@6.8.0(react@19.2.6))(react@19.2.6)
@@ -2783,11 +2787,11 @@ snapshots:
       viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.6.1
-      envio-darwin-x64: 3.6.1
-      envio-linux-arm64: 3.6.1
-      envio-linux-x64: 3.6.1
-      envio-linux-x64-musl: 3.6.1
+      envio-darwin-arm64: 3.8.0
+      envio-darwin-x64: 3.8.0
+      envio-linux-arm64: 3.8.0
+      envio-linux-x64: 3.8.0
+      envio-linux-x64-musl: 3.8.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2800,7 +2804,7 @@ snapshots:
       - vitest
       - zod
 
-  envio@3.6.1(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
+  envio@3.8.0(react-dom@19.2.6(react@19.2.7))(typescript@6.0.3)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2815,7 +2819,7 @@ snapshots:
       date-fns: 3.3.1
       dotenv: 16.4.5
       eventsource: 4.1.0
-      express: 4.20.0
+      express: 4.22.2
       ink: 6.8.0(react@19.2.6)
       ink-big-text: 2.0.0(ink@6.8.0(react@19.2.6))(react@19.2.6)
       ink-spinner: 5.0.0(ink@6.8.0(react@19.2.6))(react@19.2.6)
@@ -2829,11 +2833,11 @@ snapshots:
       viem: 2.54.0(typescript@6.0.3)(zod@3.25.76)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.6.1
-      envio-darwin-x64: 3.6.1
-      envio-linux-arm64: 3.6.1
-      envio-linux-x64: 3.6.1
-      envio-linux-x64-musl: 3.6.1
+      envio-darwin-arm64: 3.8.0
+      envio-darwin-x64: 3.8.0
+      envio-linux-arm64: 3.8.0
+      envio-linux-x64: 3.8.0
+      envio-linux-x64-musl: 3.8.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -2911,36 +2915,36 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.20.0:
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
       body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.7.0
+      cookie: 0.7.2
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.2.0
+      finalhandler: 1.3.2
       fresh: 0.5.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
-      serve-static: 1.16.0
+      serve-static: 1.16.3
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -2980,14 +2984,14 @@ snapshots:
 
   fflate@0.8.2: {}
 
-  finalhandler@1.2.0:
+  finalhandler@1.3.2:
     dependencies:
       debug: 2.6.9
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
@@ -3351,9 +3355,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -3453,12 +3458,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.0:
+  send@0.19.2:
     dependencies:
-      encodeurl: 1.0.2
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3484,7 +3507,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ overrides:
   tmp@<=0.2.3: 0.2.4
   undici@>=7.0.0 <7.24.0: 7.24.0
   yaml@<2.8.3: 2.8.3
+  fflate@<0.8.3: 0.8.3
   body-parser@<1.20.6: 1.20.6
   cookie@<0.7.0: 0.7.0
   express@<4.22.2: 4.22.2
@@ -1093,8 +1094,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -2335,7 +2336,7 @@ snapshots:
       '@fuel-ts/errors': 0.103.0
       '@fuel-ts/math': 0.103.0
       '@fuel-ts/versions': 0.103.0
-      fflate: 0.8.2
+      fflate: 0.8.3
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.3))
 
   '@fuel-ts/versions@0.103.0':
@@ -2982,7 +2983,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   finalhandler@1.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 blockExoticSubdeps: true
 engineStrict: true
+fetchRetries: 3
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   # qs 6.16.0 is the only release fixing GHSA-x5fp-wj9c-mxmx and

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,6 +85,9 @@ overrides:
   "tmp@<=0.2.3": "0.2.4"
   "undici@>=7.0.0 <7.24.0": "7.24.0"
   "yaml@<2.8.3": "2.8.3"
+  # Envio pulls fflate through @fuel-ts/utils. GHSA-px8p-9vwx-vf98 can
+  # loop indefinitely on malformed ZIP64 input and is fixed in 0.8.3.
+  "fflate@<0.8.3": "0.8.3"
   # Envio bundles express + ws; patches the transitive advisories CI's
   # audit gate flagged at moderate+. Pinned to ranges known to address
   # each CVE without churning unrelated majors.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  # qs 6.16.0 is the only release fixing GHSA-x5fp-wj9c-mxmx and
+  # GHSA-4mjr-xmp4-gh2g. Remove this exception after 2026-09-05T23:50:15Z.
+  - qs@6.16.0
 allowBuilds:
   # esbuild ships native binaries it builds on install; required because
   # vitest (our test runner) depends on it transitively. Without this entry,
@@ -86,9 +90,9 @@ overrides:
   # each CVE without churning unrelated majors.
   "body-parser@<1.20.6": "1.20.6"
   "cookie@<0.7.0": "0.7.0"
-  "express@<4.20.0": "4.20.0"
+  "express@<4.22.2": "4.22.2"
   "path-to-regexp@<0.1.13": "0.1.13"
-  "qs@<6.15.2": "6.15.2"
+  "qs@<6.16.0": "6.16.0"
   "send@<0.19.0": "0.19.0"
   "serve-static@<1.16.0": "1.16.0"
   # postcss GHSA-r28c-9q8g-f849 (high, arbitrary source-map disclosure),


### PR DESCRIPTION
## Summary

Clears the current `qs` and `fflate` advisories in the Envio runtime dependency path, updates the Hasura package layer for the reported `libp11-kit0` findings, and makes the required audit check resilient to transient npm advisory-endpoint timeouts.

- Updates Envio to `3.8.0` and the Express override to `4.22.2`.
- Forces `qs@6.16.0`, which resolves `GHSA-x5fp-wj9c-mxmx` and `GHSA-4mjr-xmp4-gh2g`.
- Adds a narrow release-age exception only for `qs@6.16.0`; remove it after `2026-09-05T23:50:15Z`.
- Forces `fflate@0.8.3`, resolving `GHSA-px8p-9vwx-vf98` in the `envio > @fuel-ts/utils` path.
- Explicitly upgrades `libp11-kit0` in the Hasura image for `CVE-2026-13757` and `CVE-2026-18938`.
- Increases pnpm registry retries from two to three. pnpm retries transport failures but leaves real moderate-or-higher audit findings authoritative.

## Validation

- Clean `pnpm install --no-frozen-lockfile`
- Clean `pnpm install --frozen-lockfile`
- `pnpm config get fetchRetries` — `3`
- `pnpm audit --audit-level moderate --json` — 0 vulnerabilities across 399 dependencies
- `pnpm why fflate` — only `fflate@0.8.3`
- Envio code generation
- Biome checks and TypeScript/client build
- All repository test commands — 269 passed, 3 skipped

A local image scan was not available because this host has no Docker-compatible runtime or Trivy; GitHub's Docker Security Scan is the authoritative verification for the rebuilt Hasura image.

## Post-Deploy Monitoring & Validation

- **Logs:** Check indexer startup and runtime logs for dependency-loading errors, unexpected exits, compression/decompression failures, or repeated npm advisory-endpoint timeouts in CI.
- **Healthy signal:** The indexer starts normally, processes its usual workload without new errors, and the dependency audit completes without a transport timeout.
- **Failure signal:** New startup failures, repeated process restarts, compression-related hangs/errors, or repeated audit failure after all configured pnpm retries.
- **Rollback trigger:** Revert the relevant override if a reproducible runtime compatibility regression appears; revert the audit retry setting if it causes unacceptable CI latency. No application behavior is intentionally changed.
- **Window and owner:** Repository maintainers during the first normal deployment cycle and next dependency-audit run after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal indexing and build tooling components.
  * Refreshed workspace package resolution and release-age settings.
  * Updated container image system packages to support the latest build environment.
  * Applied maintenance updates across workspace applications for improved consistency and reliability.
  * Improved package retrieval resilience by allowing additional retries and applying updated security safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
